### PR TITLE
CommentController: redirect to submission on comment(). Closes #105

### DIFF
--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -100,6 +100,16 @@ final class CommentController extends AbstractController {
             $em->persist($reply);
             $em->flush();
 
+            // Nested comment - go to parent comment
+            if ($reply->getParent() !== null) {
+              return $this->redirectToRoute('comment', [
+                  'forum_name' => $forum->getName(),
+                  'submission_id' => $submission->getId(),
+                  'comment_id' => $reply->getParent()->getId(),
+              ]);
+            }
+
+            // By default - go to post
             return $this->redirectToRoute('submission', [
                 'forum_name' => $forum->getName(),
                 'submission_id' => $submission->getId(),

--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -100,10 +100,10 @@ final class CommentController extends AbstractController {
             $em->persist($reply);
             $em->flush();
 
-            return $this->redirectToRoute('comment', [
+            return $this->redirectToRoute('submission', [
                 'forum_name' => $forum->getName(),
                 'submission_id' => $submission->getId(),
-                'comment_id' => $reply->getId(),
+                'slug' => Slugger::slugify($submission->getTitle()),
             ]);
         }
 


### PR DESCRIPTION
#105 

Test Plan:
- Go to any Post
- Comment on it once
- Comment on it second time
- Page displayed should show 2 comments and no "See all comments" should be present

- Now reply to one of the comments
- Only these 2 comments should be displayed after reddirect 
- "Viewing a single comment thread." View all comments should be present