### PR TITLE
Read/Unread Notifications

### DIFF
--- a/config/app_routes/user.yaml
+++ b/config/app_routes/user.yaml
@@ -76,10 +76,12 @@ mark_user_trusted:
 
 inbox:
     controller: App\Controller\UserController::inbox
-    defaults: { page: 1 }
-    path: /inbox/{page}
+    defaults: { filter: unread, page: 1 }
+    path: /inbox/{filter}/{page}
     methods: [GET]
-    requirements: { page: \d+ }
+    requirements: 
+        page: \d+
+        filter: all|unread
 
 clear_inbox:
     controller: App\Controller\UserController::clearInbox

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -317,12 +317,12 @@ final class UserController extends AbstractController {
      *
      * @return Response
      */
-    public function inbox(int $page) {
+    public function inbox(string $filter, int $page) {
         /* @var User $user */
         $user = $this->getUser();
 
         return $this->render('user/inbox.html.twig', [
-            'notifications' => $user->getPaginatedNotifications($page),
+            'notifications' => $user->getPaginatedNotifications($filter, $page),
         ]);
     }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -323,6 +323,7 @@ final class UserController extends AbstractController {
 
         return $this->render('user/inbox.html.twig', [
             'notifications' => $user->getPaginatedNotifications($filter, $page),
+            'current_filter' => $filter,
         ]);
     }
 

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -55,4 +55,8 @@ abstract class Notification {
     public function getUser(): User {
         return $this->user;
     }
+
+    public function getRead(): bool {
+      return $this->read;
+    }
 }

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -33,8 +33,17 @@ abstract class Notification {
      */
     private $user;
 
+
+    /**
+     * @ORM\Column(name="read", type="boolean", options={"default":false}, nullable=false)
+     *
+     * @var bool 
+     */
+    private $read;
+
     public function __construct(User $receiver) {
         $this->user = $receiver;
+        $this->read = false;
     }
 
     abstract public function getType(): string;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -467,13 +467,17 @@ class User implements UserInterface, EquatableInterface {
     }
 
     /**
+     * @param string $filter unread|all
      * @param int $page
      * @param int $maxPerPage
      *
      * @return Pagerfanta|Notification[]
      */
-    public function getPaginatedNotifications(int $page, int $maxPerPage = 25): Pagerfanta {
+    public function getPaginatedNotifications(string $filter, int $page, int $maxPerPage = 25): Pagerfanta {
         $criteria = Criteria::create()->orderBy(['id' => 'DESC']);
+        if ($filter === 'unread') {
+          $criteria = $this->_unreadNotificationsCriteria($criteria);
+        }
 
         $notifications = new Pagerfanta(new DoctrineSelectableAdapter($this->notifications, $criteria));
         $notifications->setMaxPerPage($maxPerPage);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -450,6 +450,22 @@ class User implements UserInterface, EquatableInterface {
         }
     }
 
+    private function _unreadNotificationsCriteria(Criteria $existingCriteria = null):Criteria 
+    {
+      $criteria = ($existingCriteria !== null) ? $existingCriteria : Criteria::create();
+      $expr = Criteria::expr();
+      $criteria = $criteria->where($expr->eq('read', false));
+      return $criteria;
+    }
+
+    /**
+     * @return Collection|Selectable|Notification[]
+     */
+    public function getUnreadNotifications(): Collection {
+        $notifs = $this->notifications;
+        return $notifs->matching($this->_unreadNotificationsCriteria());
+    }
+
     /**
      * @param int $page
      * @param int $maxPerPage

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -450,8 +450,7 @@ class User implements UserInterface, EquatableInterface {
         }
     }
 
-    private function _unreadNotificationsCriteria(Criteria $existingCriteria = null):Criteria 
-    {
+    private function _unreadNotificationsCriteria(Criteria $existingCriteria = null):Criteria {
       $criteria = ($existingCriteria !== null) ? $existingCriteria : Criteria::create();
       $expr = Criteria::expr();
       $criteria = $criteria->where($expr->eq('read', false));

--- a/src/Migrations/Version20180328082928.php
+++ b/src/Migrations/Version20180328082928.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180328082928 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE notifications ADD read BOOLEAN DEFAULT \'false\' NOT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE notifications DROP read');
+    }
+}

--- a/src/Migrations/Version20180328082928.php
+++ b/src/Migrations/Version20180328082928.php
@@ -6,13 +6,12 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
+ * Auto-generated and manually edited Migration - adds 'read' boolean field no notifications
  */
 class Version20180328082928 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('ALTER TABLE notifications ADD read BOOLEAN DEFAULT \'false\' NOT NULL');
@@ -20,7 +19,6 @@ class Version20180328082928 extends AbstractMigration
 
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('ALTER TABLE notifications DROP read');

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -20,7 +20,8 @@ class NotificationRepository extends ServiceEntityRepository {
      */
     public function clearInbox(User $user, int $max = null) {
         $qb = $this->getEntityManager()->createQueryBuilder()
-            ->delete(Notification::class, 'n')
+            ->update(Notification::class, 'n')
+            ->set('n.read', true)
             ->where('n.user = ?1')
             ->setParameter(1, $user);
 
@@ -39,7 +40,8 @@ class NotificationRepository extends ServiceEntityRepository {
      */
     public function clearNotification(User $user, int $notificationId = null) {
         $qb = $this->getEntityManager()->createQueryBuilder()
-            ->delete(Notification::class, 'n')
+            ->update(Notification::class, 'n')
+            ->set('n.read', 'true')
             ->where('n.user = ?1')
             ->setParameter(1, $user)
             ->andWhere('n.id = ?2')

--- a/templates/_includes/site_nav.html.twig
+++ b/templates/_includes/site_nav.html.twig
@@ -1,6 +1,6 @@
 {% from '_macros/icon.html.twig' import icon %}
 {% spaceless %}
-  {%- set notification_count = is_granted('ROLE_USER') ? app.user.notifications|length : 0 -%}
+  {%- set notification_count = is_granted('ROLE_USER') ? app.user.unreadnotifications|length : 0 -%}
 
   <nav class="site-nav">
 

--- a/templates/user/inbox.html.twig
+++ b/templates/user/inbox.html.twig
@@ -59,7 +59,7 @@
 {% block notification_message_thread %}
   {% from 'message/_macros.html.twig' import message_thread %}
 
-  <h1 class="notification-head">
+  <h1 class="notification-head {{ (notification.read != true) ? 'notification-head-active' : 'notification-head-inactive' }}">
     <a href="{{ path('message', {id: notification.thread.id}) }}">
       {{- notification.thread.title -}}
     </a>
@@ -71,7 +71,7 @@
 {% block notification_message_reply %}
   {% from 'message/_macros.html.twig' import message_reply %}
 
-  <h1 class="notification-head">
+  <h1 class="notification-head {{ (notification.read != true) ? 'notification-head-active' : 'notification-head-inactive' }}">
     <a href="{{ path('message', {id: notification.reply.thread.id}) }}#mr{{ notification.reply.id }}">
       {{ 'inbox.message_reply_head'|trans({'%title%': notification.reply.thread.title}) -}}
     </a>

--- a/templates/user/inbox.html.twig
+++ b/templates/user/inbox.html.twig
@@ -84,7 +84,7 @@
   <form action="{{ path('clear_notification', { id: notification.id }) }}" method="POST">
     <input type="hidden" name="token" value="{{ csrf_token('clear_notification') }}">
       <div>
-        <button type="submit" class="clear-notification-button">Clear notification</button>
+        <button type="submit" class="clear-notification-button">{{ 'inbox.clear_notification'|trans }}</button>
       </div>
   </form>
 {% endblock %}

--- a/templates/user/inbox.html.twig
+++ b/templates/user/inbox.html.twig
@@ -14,6 +14,20 @@
 
 {% block body %}
   <h1 class="page-heading">{{ 'inbox.title'|trans }}</h1>
+  <nav class="tabs submission-sort">
+      <ul class="tabs__bar">
+      {%- set attr = app.request.attributes -%}
+      {%- spaceless -%}
+        {%- for type in ['unread', 'all'] -%}
+          <li class="tabs__tab {{ type == current_filter ? 'tabs__tab--active active' }}">
+          <a href="{{ path(attr.get('_route'), (attr.get('_route_params') ?? [])|merge({page: 1, filter: type})) }}" class="tabs__link {{ type == current_filter ? 'tabs__link--active' }}">
+          {{- ('inbox.filter_'~type)|trans -}}
+          </a>
+        </li>
+        {%- endfor -%}
+      {%- endspaceless -%}
+      </ul>
+  </nav>
 
   {% if notifications|length > 0 %}
     <form action="{{ path('clear_inbox', { max: notifications|first.id }) }}" method="POST" class="form">

--- a/templates/user/inbox.html.twig
+++ b/templates/user/inbox.html.twig
@@ -41,7 +41,9 @@
   {% endif %}
 
   {% for notification in notifications %}
-    {{ block('clear_notification_button') }}
+    {% if notification.read != true %}
+      {{ block('clear_notification_button') }}
+    {% endif %}
     {{ block('notification_'~notification.type) }}
   {% endfor %}
 

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -98,8 +98,8 @@ flash:
     forum_deleted: The forum and all its contents have been deleted.
     forum_updated: The changes have been saved.
     forum_moderator_added: The user has been promoted to moderator.
-    inbox_cleared: The inbox was cleared.
-    notification_cleared: The notification was successfully cleared.
+    inbox_cleared: The inbox was marked as read.
+    notification_cleared: The notification was marked as read.
     reset_password_email_sent: A reset email has been sent to the address you specified.
     theme_created: Your theme has been created.
     theme_updated: The theme has been updated.
@@ -199,9 +199,12 @@ help:
 
 inbox:
     title: Inbox
-    clear_inbox: Clear inbox
+    clear_inbox: Mark All As Read 
+    clear_notification: Mark As Read 
     empty: The inbox is empty.
     message_reply_head: 'Re: %title%'
+    filter_all: 'All'
+    filter_unread: 'Unread'
 
 item:
     short_url: 'Short URL: %url%'


### PR DESCRIPTION
So if you go through commits - this should be easier to review.

So before it was just deleting notifications.
Now we're marking this stuff as read.

TODO before this can be merged:
- [x] add UI for tabs
- [x] check that pagination respects current tab, fix if necessary
- [x] change "Clear Notification" & "Clear All" to "Mark (All) As Read"
- [x] Provide a detailed test-plan and actually go through it

**Test-Plan**
Pre-Req:
 - 2 different users on 2 different browsers
 - message each other a bit
 - with Chrome console - copy submit message as cURL to spam another user super quick from terminal
 - Do it like 20 times


User 1:
Refresh page - should see INbox with some number of notifs
Go Mark some of them as read, refresh page - number should go down
Mark all as read - Inbox should dissapear from navigation pane
Go to inbox through URL - click all - should see all prev notifications

User 2:
Must have 20+ notifs
Mark some of them as read, until Unread page doesn't have "Next" button anymore
Go to All - Previous button should appear and be functional
Open Chrome console - compare H1 of read vs unread notification - should have different CSS classes -active and -inactive
