### PR TITLE
implementing user groups

### DIFF
--- a/config/app_routes/group.yaml
+++ b/config/app_routes/group.yaml
@@ -1,0 +1,28 @@
+groups:
+    controller: App\Controller\GroupController::list
+    defaults: { page: 1 }
+    path: /groups/{page}
+    methods: [GET]
+    requirements: { page: \d+ }
+
+group:
+    controller: App\Controller\GroupController::group
+    defaults: { page: 1 }
+    path: /group/{name}/{page}
+    methods: [GET]
+    requirements: { page: \d+ }
+
+create_group:
+    controller: App\Controller\GroupController::create
+    path: /create_group
+    methods: [GET, POST]
+
+edit_group:
+    controller: App\Controller\GroupController::edit
+    methods: [GET, POST]
+    path: /edit_group/{name}
+
+add_to_group:
+    controller: App\Controller\GroupController::addToGroup
+    methods: [GET, POST]
+    path: /set_group/{username}

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -37,6 +37,9 @@ _user:
 _wiki:
     resource: app_routes/wiki.yaml
 
+_group:
+    resource: app_routes/group.yaml
+
 _static_pages:
     resource: app_routes/static_pages.yaml
 

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\UserGroup;
+use App\Entity\User;
+use App\Form\UserGroupType;
+use App\Form\UserToGroupType;
+use App\Form\Model\UserGroupData;
+use App\Form\Model\UserData;
+use App\Repository\UserGroupRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManager;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Entity("group", expr="repository.findOneOrRedirectToCanonical(name, 'group_name')")
+ */
+final class GroupController extends AbstractController {
+    /**
+     * @IsGranted("ROLE_ADMIN")
+     *
+     * @param UserGroupRepository $group
+     * @param int            $page
+     * @param Request        $request
+     *
+     * @return Response
+     */
+    public function list(UserGroupRepository $group, int $page, Request $request) {
+        return $this->render('group/list.html.twig', [
+            'page' => $page,
+            'groups' => $group->findPaginated($page),
+        ]);
+    }
+
+    /**
+     * @IsGranted("ROLE_ADMIN")
+     *
+     * @param Request       $request
+     * @param EntityManager $em
+     *
+     * @return Response
+     */
+    public function create(Request $request, EntityManager $em): Response {
+        $data = new UserGroupData();
+
+        $form = $this->createForm(UserGroupType::class, $data);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $group = $data->toUserGroup();
+
+            $em->persist($group);
+            $em->flush();
+
+            return $this->redirectToRoute('groups');
+        }
+
+        return $this->render('group/create.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @IsGranted("ROLE_ADMIN")
+     *
+     * @param UserGroup     $userGroup
+     * @param Request       $request
+     * @param EntityManager $em
+     *
+     * @return Response
+     */
+    public function edit(UserGroup $userGroup, Request $request, EntityManager $em): Response {
+        $data = new UserGroupData($userGroup);
+
+        $form = $this->createForm(UserGroupType::class, $data);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data->updateUserGroup($userGroup);
+
+            $em->flush();
+
+            return $this->redirectToRoute('groups');
+        }
+
+        return $this->render('group/edit.html.twig', [
+            'group' => $userGroup,
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @IsGranted("ROLE_ADMIN")
+     *
+     * @param UserRepository $ur
+     * @param UserGroup     $userGroup
+     * @param int           $page
+     * @param Request       $request
+     * @param EntityManager $em
+     *
+     * @return Response
+     */
+    public function group(UserRepository $ur, UserGroup $userGroup, int $page, Request $request, EntityManager $em): Response {
+        $users = $ur->getPaginatedUsersInGroup($userGroup, $page);
+        return $this->render('group/group.html.twig', [
+            'group' => $userGroup,
+            'page' => $page,
+            'users' => $users
+        ]);
+    }
+
+    /**
+     * @IsGranted("ROLE_ADMIN")
+     *
+     * @param UserGroupRepository $ugm
+     * @param User          $user
+     * @param Request       $request
+     * @param EntityManager $em
+     *
+     * @return Response
+     */
+    public function addToGroup(UserGroupRepository $ugm, User $user, Request $request, EntityManager $em): Response {
+        $data = UserData::fromUser($user);
+
+        $form = $this->createForm(UserToGroupType::class, $data);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data->updateUser($user);
+
+            $em->persist($user);
+            $em->flush();
+
+            return $this->redirectToRoute('groups');
+        }
+
+        return $this->render('group/add.html.twig', [
+            'form' => $form->createView(),
+            'user' => $user
+        ]);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -229,6 +229,13 @@ class User implements UserInterface, EquatableInterface {
      */
     private $autoFetchSubmissionTitles = true;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="UserGroup", inversedBy="users")
+     *
+     * @var UserGroup|null
+     */
+    private $group = null;
+
     public function __construct(string $username, string $password, \DateTime $created = null) {
         $this->setUsername($username);
         $this->password = $password;
@@ -582,6 +589,14 @@ class User implements UserInterface, EquatableInterface {
 
     public function setBiography(?string $biography) {
         $this->biography = $biography;
+    }
+
+    public function getGroup(): ?UserGroup {
+        return $this->group;
+    }
+
+    public function setGroup(?UserGroup $group) {
+        $this->group = $group;
     }
 
     public function autoFetchSubmissionTitles(): bool {

--- a/src/Entity/UserGroup.php
+++ b/src/Entity/UserGroup.php
@@ -58,9 +58,10 @@ class UserGroup {
      */
     private $displayTitle = false;
 
-    public function __construct(string $name, string $title) {
+    public function __construct(string $name, string $title, bool $displayTitle) {
         $this->setName($name);
         $this->title = $title;
+        $this->displayTitle = $displayTitle;
         $this->users = new ArrayCollection();
     }
 

--- a/src/Entity/UserGroup.php
+++ b/src/Entity/UserGroup.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\UserGroupRepository")
+ * @ORM\Table(name="user_group", uniqueConstraints={
+ *     @ORM\UniqueConstraint(name="user_group_name_idx", columns={"name"}),
+ *     @ORM\UniqueConstraint(name="user_group_normalized_name_idx", columns={"normalized_name"})
+ * })
+ */
+class UserGroup {
+    /**
+     * @ORM\Column(type="bigint")
+     * @ORM\GeneratedValue()
+     * @ORM\Id()
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="text", unique=true)
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="text", unique=true)
+     *
+     * @var string
+     */
+    private $normalizedName;
+
+    /**
+     * @ORM\Column(type="text")
+     *
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @ORM\OneToMany(targetEntity="User", mappedBy="group")
+     * @ORM\OrderBy({"normalizedUsername": "ASC"})
+     *
+     * @var User[]|Collection|Selectable
+     */
+    private $users;
+
+    /**
+     * @ORM\Column(type="boolean", options={"default": false})
+     */
+    private $displayTitle = false;
+
+    public function __construct(string $name, string $title) {
+        $this->setName($name);
+        $this->title = $title;
+        $this->users = new ArrayCollection();
+    }
+
+    public function getId(): ?int {
+        // todo: replace with UUID
+        return $this->id;
+    }
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    public function setName(string $name): void {
+        $this->name = $name;
+        $this->normalizedName = self::normalizeName($name);
+    }
+
+    public function getNormalizedName(): string {
+        return $this->normalizedName;
+    }
+
+    public function getTitle(): string {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void {
+        $this->title = $title;
+    }
+
+    /**
+     * @return Collection|Selectable|User[]
+     */
+    public function getUsers(): Collection {
+        return $this->users;
+    }
+
+    public static function normalizeName(string $name) {
+        return Forum::normalizeName($name);
+    }
+
+    public function getDisplayTitle() {
+        return $this->displayTitle;
+    }
+
+    public function setDisplayTitle($displayTitle) {
+        $this->displayTitle =  $displayTitle;
+    }
+}
+

--- a/src/Entity/UserGroup.php
+++ b/src/Entity/UserGroup.php
@@ -25,21 +25,21 @@ class UserGroup {
     private $id;
 
     /**
-     * @ORM\Column(type="text", unique=true)
+     * @ORM\Column(type="string", unique=true, length=50)
      *
      * @var string
      */
     private $name;
 
     /**
-     * @ORM\Column(type="text", unique=true)
+     * @ORM\Column(type="string", unique=true, length=50)
      *
      * @var string
      */
     private $normalizedName;
 
     /**
-     * @ORM\Column(type="text")
+     * @ORM\Column(type="string", length=50)
      *
      * @var string
      */

--- a/src/Form/Model/UserData.php
+++ b/src/Form/Model/UserData.php
@@ -76,6 +76,11 @@ class UserData implements UserInterface {
 
     private $autoFetchSubmissionTitles;
 
+    /**
+     * @var UserGroup|null
+     */
+    private $group;
+
     public static function fromUser(User $user): self {
         $self = new self();
         $self->entityId = $user->getId();
@@ -89,6 +94,7 @@ class UserData implements UserInterface {
         $self->openExternalLinksInNewTab = $user->openExternalLinksInNewTab();
         $self->biography = $user->getBiography();
         $self->autoFetchSubmissionTitles = $user->autoFetchSubmissionTitles();
+        $self->group = $user->getGroup();
 
         return $self;
     }
@@ -109,12 +115,14 @@ class UserData implements UserInterface {
         $user->setOpenExternalLinksInNewTab($this->openExternalLinksInNewTab);
         $user->setBiography($this->biography);
         $user->setAutoFetchSubmissionTitles($this->autoFetchSubmissionTitles);
+        $user->setGroup($this->getGroup());
     }
 
     public function toUser(): User {
         $user = new User($this->username, $this->password);
         $user->setEmail($this->email);
         $user->setBiography($this->biography);
+        $user->setGroup($this->group);
 
         $settings = [
             'showCustomStylesheets',
@@ -177,6 +185,14 @@ class UserData implements UserInterface {
 
     public function setEmail($email) {
         $this->email = $email;
+    }
+
+    public function getGroup() {
+        return $this->group;
+    }
+
+    public function setGroup($group) {
+        $this->group = $group;
     }
 
     public function getLocale() {

--- a/src/Form/Model/UserGroupData.php
+++ b/src/Form/Model/UserGroupData.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Form\Model;
+
+use App\Entity\UserGroup;
+use App\Validator\Constraints\Unique;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @Unique(entityClass="App\Entity\UserGroup", errorPath="name",
+ *     fields={"normalizedName"}, idFields={"entityId": "id"})
+ */
+final class UserGroupData {
+    /**
+     * @var int|null
+     */
+    private $entityId;
+
+    /**
+     * @Assert\Length(min=3, max=40)
+     * @Assert\NotBlank()
+     * @Assert\Regex("/^\w+$/")
+     *
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * @var string|null
+     */
+    private $normalizedName;
+
+    /**
+     * @Assert\Length(min=1, max=80)
+     * @Assert\NotBlank()
+     *
+     * @var string|null
+     */
+    private $title;
+
+    /**
+     * @var bool
+     */
+    private $displayTitle = false;
+
+    public function __construct(UserGroup $userGroup = null) {
+        if ($userGroup) {
+            $this->entityId = $userGroup->getId();
+            $this->setName($userGroup->getName());
+            $this->title = $userGroup->getTitle();
+            $this->displayTitle = $userGroup->getDisplayTitle();
+        }
+    }
+
+    public function toUserGroup(): UserGroup {
+        return new UserGroup($this->name, $this->title);
+    }
+
+    public function updateUserGroup(UserGroup $userGroup): void {
+        $userGroup->setName($this->name);
+        $userGroup->setTitle($this->title);
+        $userGroup->setDisplayTitle($this->displayTitle);
+    }
+
+    public function getEntityId(): ?int {
+        return $this->entityId;
+    }
+
+    public function getName(): ?string {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void {
+        $this->name = $name;
+        $this->normalizedName = isset($name)
+            ? UserGroup::normalizeName($name)
+            : null;
+    }
+
+    public function getNormalizedName(): ?string {
+        return $this->normalizedName;
+    }
+
+    public function getTitle(): ?string {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void {
+        $this->title = $title;
+    }
+
+
+    public function getDisplayTitle() {
+        return $this->displayTitle;
+    }
+    public function setDisplayTitle($displayTitle) {
+        $this->displayTitle = $displayTitle;
+    }
+}

--- a/src/Form/Model/UserGroupData.php
+++ b/src/Form/Model/UserGroupData.php
@@ -53,7 +53,7 @@ final class UserGroupData {
     }
 
     public function toUserGroup(): UserGroup {
-        return new UserGroup($this->name, $this->title);
+        return new UserGroup($this->name, $this->title, $this->displayTitle);
     }
 
     public function updateUserGroup(UserGroup $userGroup): void {

--- a/src/Form/UserGroupType.php
+++ b/src/Form/UserGroupType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Form;
+
+use App\Form\Model\UserGroupData;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UserGroupType extends AbstractType {
+    public function buildForm(FormBuilderInterface $builder, array $options) {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'label.name',
+            ])
+            ->add('title', TextType::class, [
+                'label' => 'label.title',
+            ])
+            ->add('display_title', CheckboxType::class, ['required' => false]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver) {
+        $resolver->setDefaults([
+            'data_class' => UserGroupData::class,
+        ]);
+    }
+}

--- a/src/Form/UserToGroupType.php
+++ b/src/Form/UserToGroupType.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Form;
+
+use App\Form\Model\UserData;
+use App\Entity\UserGroup;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+final class UserToGroupType extends AbstractType {
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker) {
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options) {
+
+        /* @var ForumData $data */
+        $data = $builder->getData();
+        $editing = $data && $data->getEntityId();
+
+        $builder->add('group', EntityType::class, [
+                'class' => UserGroup::class,
+                'choice_label' => 'name',
+                'query_builder' => function (EntityRepository $repository) {
+                    return $repository->createQueryBuilder('ug')
+                        ->orderBy('ug.name', 'ASC');
+                },
+                'required' => false,
+                'placeholder' => 'forum_form.uncategorized_placeholder',
+            ]);
+
+        $builder->add('submit', SubmitType::class, [
+            'label' => $editing ? 'forum_form.save' : 'forum_form.create',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver) {
+        $resolver->setDefaults([
+            'data_class' => UserData::class,
+            'label_format' => 'user_form.%name%',
+            'validation_groups' => function (FormInterface $form) {
+                $editing = $form->getData() && $form->getData()->getEntityId();
+
+                return $editing ? ['edit'] : ['create'];
+            },
+        ]);
+    }
+}

--- a/src/Migrations/Version20180329172031.php
+++ b/src/Migrations/Version20180329172031.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180329172031 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SEQUENCE user_group_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE user_group (id BIGINT NOT NULL, name TEXT NOT NULL, normalized_name TEXT NOT NULL, title TEXT NOT NULL, display_title BOOLEAN DEFAULT \'false\' NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX user_group_name_idx ON user_group (name)');
+        $this->addSql('CREATE UNIQUE INDEX user_group_normalized_name_idx ON user_group (normalized_name)');
+        $this->addSql('ALTER TABLE users ADD group_id BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE users ADD CONSTRAINT FK_1483A5E9FE54D947 FOREIGN KEY (group_id) REFERENCES user_group (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_1483A5E9FE54D947 ON users (group_id)');
+        $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id DROP DEFAULT');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE users DROP CONSTRAINT FK_1483A5E9FE54D947');
+        $this->addSql('DROP SEQUENCE user_group_id_seq CASCADE');
+        $this->addSql('DROP TABLE user_group');
+        $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');
+        $this->addSql('DROP INDEX IDX_1483A5E9FE54D947');
+        $this->addSql('ALTER TABLE users DROP group_id');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id DROP DEFAULT');
+    }
+}

--- a/src/Migrations/Version20180329172031.php
+++ b/src/Migrations/Version20180329172031.php
@@ -16,11 +16,11 @@ class Version20180329172031 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('CREATE SEQUENCE user_group_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
-        $this->addSql('CREATE TABLE user_group (id BIGINT NOT NULL, name TEXT NOT NULL, normalized_name TEXT NOT NULL, title TEXT NOT NULL, display_title BOOLEAN DEFAULT \'false\' NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE user_group (id BIGINT NOT NULL, name VARCHAR(50) NOT NULL, normalized_name VARCHAR(50) NOT NULL, title VARCHAR(50) NOT NULL, display_title BOOLEAN DEFAULT \'false\' NOT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX user_group_name_idx ON user_group (name)');
         $this->addSql('CREATE UNIQUE INDEX user_group_normalized_name_idx ON user_group (normalized_name)');
         $this->addSql('ALTER TABLE users ADD group_id BIGINT DEFAULT NULL');
-        $this->addSql('ALTER TABLE users ADD CONSTRAINT FK_1483A5E9FE54D947 FOREIGN KEY (group_id) REFERENCES user_group (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE users ADD CONSTRAINT FK_1483A5E9FE54D947 FOREIGN KEY (group_id) REFERENCES user_group (id)');
         $this->addSql('CREATE INDEX IDX_1483A5E9FE54D947 ON users (group_id)');
         $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
         $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');

--- a/src/Repository/UserGroupRepository.php
+++ b/src/Repository/UserGroupRepository.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\UserGroup;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @method User|null findOneByName(string|string[] $name)
+ */
+class UserGroupRepository extends ServiceEntityRepository {
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(
+        ManagerRegistry $registry,
+        UrlGeneratorInterface $urlGenerator,
+        RequestStack $requestStack
+    ) {
+        parent::__construct($registry, UserGroup::class);
+
+        $this->urlGenerator = $urlGenerator;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadGroupByName($name) {
+        if ($name === null) {
+            return null;
+        }
+
+        return $this->findOneByNormalizednName(UserGroup::normalizeName($name));
+    }
+
+    public function findOneOrRedirectToCanonical(?string $name, string $param): ?Group {
+        $group = $this->loadGroupByName($name);
+
+        if ($group && $user->getName() !== $name) {
+            $request = $this->requestStack->getCurrentRequest();
+
+            if (
+                !$request ||
+                $this->requestStack->getParentRequest() ||
+                !$request->isMethodCacheable()
+            ) {
+                return $group;
+            }
+
+            $route = $request->attributes->get('_route');
+            $params = $request->attributes->get('_route_params', []);
+            $params[$param] = $group->getName();
+
+            throw new HttpException(302, 'Redirecting to canonical', null, [
+                'Location' => $this->urlGenerator->generate($route, $params),
+            ]);
+        }
+
+        return $group;
+    }
+
+    /**
+     * @param int      $page
+     * @param Criteria $criteria
+     *
+     * @return Group[]|Pagerfanta
+     */
+    public function findPaginated(int $page) {
+        $qb = $this->createQueryBuilder('g');
+        $pager = new Pagerfanta(new DoctrineORMAdapter($qb));
+        $pager->setMaxPerPage(25);
+        $pager->setCurrentPage($page);
+
+        return $pager;
+    }
+
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,12 +5,14 @@ namespace App\Repository;
 use App\Entity\Comment;
 use App\Entity\Submission;
 use App\Entity\User;
+use App\Entity\UserGroup;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Pagerfanta\Adapter\DoctrineSelectableAdapter;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -194,4 +196,16 @@ EOSQL;
             yield $ip;
         }
     }
+
+    public function getPaginatedUsersInGroup(UserGroup $userGroup, $page) {
+        $qb = $this->createQueryBuilder('u')
+            ->where('u.group = :group')
+            ->setParameter('group', $userGroup);
+        $pager = new Pagerfanta(new DoctrineORMAdapter($qb, false, false));
+        $pager->setMaxPerPage(25);
+        $pager->setCurrentPage($page);
+        return $pager;
+    }
+
+
 }

--- a/templates/_includes/site_nav.html.twig
+++ b/templates/_includes/site_nav.html.twig
@@ -28,6 +28,7 @@
             <ul class="dropdown-menu">
               <li><a href="{{ path('user_bans') }}">{{ icon('hammer') }} {{ 'label.bans'|trans }}</a></li>
               <li><a href="{{ path('manage_forum_categories') }}">{{ icon('sitemap') }} {{ 'nav.forum_categories'|trans }}</a></li>
+              <li><a href="{{ path('groups') }}">{{ icon('sitemap') }} {{ 'nav.groups'|trans }}</a></li>
               <li><a href="{{ path('users') }}">{{ icon('user') }} {{ 'nav.users'|trans }}</a></li>
             </ul>
           </li>

--- a/templates/comment/_macros.html.twig
+++ b/templates/comment/_macros.html.twig
@@ -96,6 +96,13 @@
       flag: comment.userFlag,
       submitter: comment.user is same as(comment.submission.user),
     }) -}}
+    {% if comment.user.group is defined %}
+      {% if comment.user.group is not null %}
+        {% if comment.user.group.displayTitle %}
+          <span class="{{ comment.user.group.normalizedname }}">{{ comment.user.group.title }}</span>
+        {% endif %}
+      {% endif %}
+    {% endif %}
   {%- else -%}
     {{- 'comments.author_deleted'|trans -}}
   {%- endif -%}

--- a/templates/group/_form.html.twig
+++ b/templates/group/_form.html.twig
@@ -1,0 +1,18 @@
+{{ form_start(form) }}
+  <div class="form__row">
+    {{ form_label(form.name) }}
+    {{ form_errors(form.name) }}
+    {{ form_widget(form.name) }}
+    <div class="form__help">
+      <p>{{ 'help.will_appear_in_the_url'|trans }}</p>
+    </div>
+  </div>
+
+  {{ form_row(form.title) }}
+
+  {{ form_row(form.display_title) }}
+
+  <div class="form__row form__button-row">
+    <button class="button">{{ (editing ? 'action.edit' : 'action.create')|trans }}</button>
+  </div>
+{{ form_end(form) }}

--- a/templates/group/add.html.twig
+++ b/templates/group/add.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block page_classes 'forum-category-create-page' %}
+{% block title 'title.add_to_group'|trans({'%user%': user.username}) %}
+
+{% block body %}
+  <h1 class="page-heading">{{ block('title') }}</h1>
+
+  {{ form_start(form) }}
+
+    {{ form_row(form.group) }}
+
+    <div class="form__row form__button-row">
+      {{ form_widget(form.submit) }}
+    </div>
+  {{ form_end(form) }}
+{% endblock %}

--- a/templates/group/create.html.twig
+++ b/templates/group/create.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block page_classes 'forum-category-create-page' %}
+{% block title 'title.create_forum_category'|trans %}
+
+{% block body %}
+  <h1 class="page-heading">{{ block('title') }}</h1>
+
+  {{ include('forum_category/_form.html.twig', {editing: false, form: form}, with_context=false) }}
+{% endblock %}

--- a/templates/group/create.html.twig
+++ b/templates/group/create.html.twig
@@ -6,5 +6,5 @@
 {% block body %}
   <h1 class="page-heading">{{ block('title') }}</h1>
 
-  {{ include('forum_category/_form.html.twig', {editing: false, form: form}, with_context=false) }}
+  {{ include('group/_form.html.twig', {editing: false, form: form}, with_context=false) }}
 {% endblock %}

--- a/templates/group/edit.html.twig
+++ b/templates/group/edit.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block page_classes 'forum-category-edit-page' %}
+{% block title 'title.editing_group'|trans({
+  '%group%': group.title
+}) %}
+
+{% block body %}
+  <h1>{{ 'title.editing_group'|trans({
+    '%group%': '<a href="%s">%s</a>'|format(
+      path('group', {name: group.name})|e,
+      group.title|e
+    )})|raw }}</h1>
+
+  {{ include('group/_form.html.twig', {form: form, editing: true}, with_context=false) }}
+{% endblock %}

--- a/templates/group/group.html.twig
+++ b/templates/group/group.html.twig
@@ -1,0 +1,41 @@
+{% extends 'base.html.twig' %}
+
+{% block page_classes 'user-list-page' %}
+{% block title 'title.list_of_users_in_group'|trans({'%group%': group.name, '%page%': page|localizednumber}) %}
+
+{% block head %}
+  {{ include('_includes/meta_pagination.html.twig', {pager: users}, with_context=false) }}
+{% endblock %}
+
+{% block body %}
+  <h1 class="page-heading">{{ block('title') }}</h1>
+
+  <a href="{{ path('groups') }}">Return to group list</a>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th>{{ 'label.id'|trans }}</th>
+        <th>{{ 'label.name'|trans }}</th>
+        <th/>
+      </tr>
+    </thead>
+
+    <tbody>
+      {% for user in users %}
+        <tr>
+          <td>{{ user.id }}</td>
+          <td><a href="{{ path('user', {username: user.username}) }}">{{ user.username }}</a></td>
+          <td>
+            <a href="{{ path('add_to_group', {username: user.username}) }}" class="button button--inline">
+              {{- 'action.edit'|trans -}}
+            </a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {{ include('_includes/pagination.html.twig', {pager: users}, with_context=false) }}
+{% endblock %}
+

--- a/templates/group/list.html.twig
+++ b/templates/group/list.html.twig
@@ -1,0 +1,49 @@
+{% extends 'base.html.twig' %}
+
+{% block page_classes 'user-list-page' %}
+{% block title 'title.list_of_groups'|trans({'%page%': page|localizednumber}) %}
+
+{% block head %}
+  {{ include('_includes/meta_pagination.html.twig', {pager: groups}, with_context=false) }}
+{% endblock %}
+
+{% block body %}
+  <h1 class="page-heading">{{ block('title') }}</h1>
+
+   <a href="{{ path('create_group') }}" class="button">
+     {{- 'action.create_group'|trans -}}
+   </a>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th>{{ 'label.id'|trans }}</th>
+        <th>{{ 'label.name'|trans }}</th>
+        <th>{{ 'label.members'|trans }}</th>
+        <th/>
+      </tr>
+    </thead>
+
+    <tbody>
+      {% for group in groups %}
+        <tr>
+          <td>{{ group.id }}</td>
+          <td><a href="{{ path('group', {name: group.name}) }}">{{ group.name }}</a></td>
+          <td>
+            {% with { count: group.users|length } %}
+              {{ count > 0 ? count|localizednumber : '-' }}
+            {% endwith %}
+          </td>
+          <td>
+            <a href="{{ path('edit_group', {name: group.name}) }}" class="button button--inline">
+              {{- 'action.edit'|trans -}}
+            </a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {{ include('_includes/pagination.html.twig', {pager: groups}, with_context=false) }}
+{% endblock %}
+

--- a/templates/submission/_macros.html.twig
+++ b/templates/submission/_macros.html.twig
@@ -26,6 +26,13 @@
     class: 'submission-submitter',
     flag: submission.userFlag,
   }) }}
+  {% if submission.user.group is defined %}
+    {% if submission.user.group is not null %}
+      {% if submission.user.group.displayTitle %}
+        <span class="{{ submission.user.group.normalizedname }}">{{ submission.user.group.title }}</span>
+      {% endif %}
+    {% endif %}
+  {% endif %}
 {%- endblock -%}
 
 {%- block submission_info_timestamp -%}

--- a/templates/user/user.html.twig
+++ b/templates/user/user.html.twig
@@ -70,6 +70,11 @@
         <li><a href="{{ path('user_forum_bans', {username: user.username}) }}">{{ 'nav.forum_bans'|trans }}</a></li>
       {% endset %}
       {% set toolbox_items = toolbox_items|merge([item]) %}
+
+      {% set item %}
+        <li><a href="{{ path('add_to_group', {username: user.username}) }}">{{ 'nav.add_to_group'|trans }}</a></li>
+      {% endset %}
+      {% set toolbox_items = toolbox_items|merge([item]) %}
     {% endif %}
   {% endif %}
 

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -25,6 +25,7 @@ action:
     filter: Filter
     create: Create
     compare: Compare
+    create_group: Create new group
 
 add_moderator:
     title: Add moderator to %forum%
@@ -287,6 +288,7 @@ label:
     posting: Posting
     auto_fetch_submission_titles: Auto-fetch submission titles
     compare: Compare
+    members: Members
 
 log:
     comment_deletion: '%user% deleted comment by %author% in "%submission%"'
@@ -336,6 +338,8 @@ nav:
     inbox_count: Inbox (%count%)
     messages: Messages
     wiki: Wiki
+    groups: Groups
+    add_to_group: Add user to group
 
     # <New Strings>
     wiki_copyright: Copyright
@@ -469,11 +473,15 @@ title:
     global_moderation_log: Global moderation log
     delete_submission: Delete submission
     list_of_users: 'List of users, page #%page%'
+    list_of_groups: 'List of groups, page #%page%'
+    list_of_users_in_group: 'List of users in %group%, page #%page%'
     user_forum_bans: "%user%'s forum bans"
     manage_forum_categories: Manage forum categories
     create_forum_category: Create forum category
     editing_forum_category: 'Editing forum category: %category%'
+    editing_group: 'Editing user group: %group%'
     wiki_diff: Showing difference between revisions %from% and %to%
+    add_to_group: 'Add %user% to group'
 
 user:
     submissions: Submissions
@@ -503,6 +511,7 @@ user_form:
     register: Register
     verification: Verification
     save: Save changes
+    group: Group
 
 user_settings:
     title: Editing user settings for %username%


### PR DESCRIPTION
This implements user groups/flairs on a 1:1 basis: https://github.com/TheRealGD/therealgd/issues/35

This is a pre-req for https://github.com/TheRealGD/therealgd/issues/19

User groups have the following info:
Name: Friendly name (Vendors)
NormalizedName: name all lower cased (vendors)
Title: Friendly Title  (Vendor)
DisplayTitle: a T/F flag

If the DisplayTitle flag is set, any post/comment a user in this group makes will be flagged with the Title next to their name. 
The title is wrapped in a <span/> element with the class set to the NormalizedName

This lets us change color/text/etc on a per group basis.

To test/use this:
To create a group:
- Login as Admin
- Browse to groups page (main nav bar: Admin > Groups)
- Use button to create group

To add/change/remove user's group:
-Login as Admin
- Browse to a users page (/user/{username})
- You can get here by clicking on a user's name in a post/comment
- In toolbox on the side click "Add user to group"

To view list of groups:
- Login as Admin
- Browse to groups page (main nav bar: Admin > Groups)

To view list of groups members:
- Login as Admin
- Browse to groups page (main nav bar: Admin > Groups)
- Click group name
On this page you can click edit next to a user to change their group
