### PR TITLE
Admin global announcements

### DIFF
--- a/assets/less/common.less
+++ b/assets/less/common.less
@@ -74,3 +74,11 @@
 .forum-group-heading a {
   color: @page-color;
 }
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}

--- a/assets/less/components/alert.less
+++ b/assets/less/components/alert.less
@@ -24,3 +24,23 @@
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+.form-message {
+
+  display: flex;
+  flex-direction: column;
+  margin: 1rem 1rem 1rem 0;
+  padding: 1rem 1rem 0;
+
+  &--primary {
+    color: @alert-primary-text-color;
+    border: 1px solid @alert-primary-border-color;
+    background: @alert-primary-color;
+  }
+
+  &--success {
+    color: @alert-success-text-color;
+    border: 1px solid @alert-success-border-color;
+    background: @alert-success-color;
+  }
+}

--- a/assets/less/settings.less
+++ b/assets/less/settings.less
@@ -51,7 +51,14 @@
 
 // Notices
 @alert-notice-color: aliceblue;
-@alert-success-color: palegreen;
+
+@alert-success-color: #c6f9d3;
+@alert-success-border-color: #a1dfb1;
+@alert-success-text-color: #002710;
+
+@alert-primary-color: #cfe5fb;
+@alert-primary-border-color: #b5cce3;
+@alert-primary-text-color: #172a3e;
 
 // Forms
 @form-error-color: red;

--- a/config/app_routes/frontpageconfig.yaml
+++ b/config/app_routes/frontpageconfig.yaml
@@ -1,0 +1,4 @@
+frontpageconfig:
+    controller: App\Controller\FrontPageConfigurationController::frontPageConfig
+    path: /frontpageconfig
+    methods: [GET, POST]

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -16,6 +16,9 @@ _forum_category:
 _front:
     resource: app_routes/front.yaml
 
+_frontpageconfig:
+    resource: app_routes/frontpageconfig.yaml
+
 _message:
     resource: app_routes/message.yaml
 

--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Entity\ForumConfiguration;
+use App\Repository\ForumRepository;
+use App\Repository\ForumConfigurationRepository;
+use App\Repository\SubmissionRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use App\Form\ForumConfigurationType;
+use App\Form\Model\ForumConfigurationData;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\HttpFoundation\Request;
+
+
+ /**
+  * @IsGranted("ROLE_ADMIN")
+  */
+final class FrontPageConfigurationController extends AbstractController {
+    public function frontPageConfig(ForumRepository $fr, SubmissionRepository $sr, ForumConfigurationRepository $fcr, EntityManager $em, Request $request) {
+        $data = new ForumConfigurationData($fcr->findSitewide());
+
+        $form = $this->createForm(ForumConfigurationType::class, $data);
+        $form->handleRequest($request);
+
+        $message = "";
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $fc = $data->toForumConfiguration();
+
+            // For sitewide settings, we need to force this to null.
+            $fc->setForumId(null);
+
+            if($fc->getId() == null || trim($fc->getId()) == "")
+                $em->persist($fc);
+            else
+                $em->merge($fc);
+
+            $em->flush();
+
+            // After saving, pull the data back down again.
+            $data = new ForumConfigurationData($fcr->findSitewide());
+            $form = $this->createForm(ForumConfigurationType::class, $data);
+
+            $message = "front_page_configuration_form.message_saved";
+        }
+
+        return $this->render('frontpageconfig/frontpageconfig.html.twig', [
+            'form' => $form->createView(),
+            'message' => $message,
+        ]);
+    }
+}

--- a/src/Entity/ForumConfiguration.php
+++ b/src/Entity/ForumConfiguration.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ORM\Mapping as ORM;
+use Pagerfanta\Adapter\DoctrineCollectionAdapter;
+use Pagerfanta\Adapter\DoctrineSelectableAdapter;
+use Pagerfanta\Pagerfanta;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\ForumConfigurationRepository")
+ * @ORM\Table(name="forum_configuration")
+ */
+class ForumConfiguration {
+    /**
+     * @ORM\Column(type="bigint")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Id()
+     *
+     * @var int|null
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="bigint", nullable=true)
+     *
+     * @var int|null
+     */
+    private $forumId;
+
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     *
+     * @var string
+     */
+    private $announcement;
+
+    public function __construct($forumId) {
+        $this->forumId = $forumId;
+    }
+
+    public function getId() {
+      return $this->id;
+    }
+
+    public function setId($id) {
+        $this->id = $id;
+    }
+
+    public function getForumId() {
+      return $this->forumId;
+    }
+
+    public function setForumId($forumId) {
+      $this->forumId = $forumId;
+    }
+
+    public function getAnnouncement() {
+        return $this->announcement;
+    }
+
+    public function setAnnouncement($announcement) {
+        $this->announcement = $announcement;
+    }
+}

--- a/src/Form/ForumConfigurationType.php
+++ b/src/Form/ForumConfigurationType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Form;
+
+use App\Form\Model\ForumConfigurationData;
+use Symfony\Component\Form\AbstractType;
+use App\Form\Type\MarkdownType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ForumConfigurationType extends AbstractType {
+    public function buildForm(FormBuilderInterface $builder, array $options) {
+        $builder
+            ->add('announcement', MarkdownType::class, [
+                'label' => 'front_page_configuration_form.announcement',
+                'required' => false
+            ])
+            ->add('id', HiddenType::class, [])
+            ->add('forumId', HiddenType::class, [])
+            ->add('submit', SubmitType::class, [
+                'label' => 'front_page_configuration_form.save',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver) {
+        $resolver->setDefaults([
+            'data_class' => ForumConfigurationData::class,
+        ]);
+    }
+}

--- a/src/Form/Model/ForumConfigurationData.php
+++ b/src/Form/Model/ForumConfigurationData.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Form\Model;
+
+use App\Entity\ForumConfiguration;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ForumConfigurationData {
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var int|null
+     */
+    public $forumId;
+
+    /**
+     * @var string|null
+     */
+    public $announcement;
+
+    public function __construct(ForumConfiguration $fc) {
+        $this->id = $fc->getId();
+        $this->forumId = $fc->getForumId();
+        $this->announcement = $fc->getAnnouncement();
+    }
+
+    public function toForumConfiguration(): ForumConfiguration {
+         $fc = new ForumConfiguration($this->forumId);
+         $fc->setId($this->id);
+         $fc->setAnnouncement($this->announcement);
+
+         return $fc;
+    }
+}

--- a/src/Migrations/Version20180330024015.php
+++ b/src/Migrations/Version20180330024015.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180330024015 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SEQUENCE forum_configuration_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE forum_configuration (id BIGINT NOT NULL, forum_id BIGINT DEFAULT NULL, announcement TEXT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP SEQUENCE forum_configuration_id_seq CASCADE');
+        $this->addSql('DROP TABLE forum_configuration');
+        $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id DROP DEFAULT');
+    }
+}

--- a/src/Repository/ForumConfigurationRepository.php
+++ b/src/Repository/ForumConfigurationRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ForumConfiguration;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+
+class ForumConfigurationRepository extends ServiceEntityRepository {
+    public function __construct(ManagerRegistry $registry) {
+        parent::__construct($registry, ForumConfiguration::class);
+    }
+
+    public function findSitewide() {
+        $config = $this->createQueryBuilder('fc')
+            ->where('fc.forumId is NULL')
+            ->getQuery()
+            ->execute();
+
+        if(count($config) == 0) {
+            return new ForumConfiguration(null);
+        }
+
+        return $config[0];
+    }
+}

--- a/templates/_includes/site_nav.html.twig
+++ b/templates/_includes/site_nav.html.twig
@@ -29,6 +29,7 @@
               <li><a href="{{ path('user_bans') }}">{{ icon('hammer') }} {{ 'label.bans'|trans }}</a></li>
               <li><a href="{{ path('manage_forum_categories') }}">{{ icon('sitemap') }} {{ 'nav.forum_categories'|trans }}</a></li>
               <li><a href="{{ path('users') }}">{{ icon('user') }} {{ 'nav.users'|trans }}</a></li>
+              <li><a href="{{ path('frontpageconfig') }}">{{ icon('settings') }} Front Page Configuration</a></li>
             </ul>
           </li>
         {% endif %}

--- a/templates/front/base.html.twig
+++ b/templates/front/base.html.twig
@@ -18,6 +18,8 @@
 {% endblock %}
 
 {% block body %}
+  {% if announcement != null %}<div class="form-message form-message--primary text-center">{{ announcement|cached_markdown(markdown_context())|raw }}</div>{% endif %}
+
   <nav class="tabs submission-sort">
     <ul class="tabs__bar">{{ submission_sort(sort_by) }}</ul>
     <ul class="tabs__bar">{{ submission_filter(listing, sort_by) }}</ul>
@@ -68,5 +70,5 @@
       </li>
     {% endwith %}
   {% endif %}
-  
+
 {%- endmacro -%}

--- a/templates/frontpageconfig/frontpageconfig.html.twig
+++ b/templates/frontpageconfig/frontpageconfig.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+
+{% block page_classes 'frontpage-config-page' %}
+{% block title 'Front Page Configuration' %}
+
+{% block body %}
+  <h1 class="page-heading">{{ block('title') }}</h1>
+
+  {% if message != "" %}<div class='form-message form-message--success'><p>{{ message|trans }}</p></div>{% endif %}
+  {{ form(form) }}
+{% endblock %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -532,3 +532,8 @@ wiki_form:
     title: Title
     body: Body
     submit: Submit
+
+front_page_configuration_form:
+    announcement: Announcement
+    save: Save Changes
+    message_saved: The changes have been saved.


### PR DESCRIPTION
For issue #84 

I have added a new page for "Front Page Configuration". This page allows you to enter in a markdown announcement that is shown on the front page. 

This can be tested by:

- Logging in as an administrator
- Clicking the "Front Page Configuration" link under "Admin" in the navigation bar
- Changing the announcement text
- Clicking save changes
- Navigating to the front page (you should observe the defined announcement)

You can remove the announcement by:

- Clicking the "Front Page Configuration" link under "Admin" in the navigation bar
- Setting the announcement text to blank
- Clicking save changes
- Navigating to the front page (the announcement should no longer be shown)
