### PR TITLE
Add docker-compose file for dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.git
+.env.dev
+.gitlab-ci.yml
+*.md

--- a/.env.dev
+++ b/.env.dev
@@ -2,7 +2,7 @@
 # Copy this file to .env file for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
-SITE_NAME=Gundeals.dev
+SITE_NAME=gundeals.local
 NO_REPLY_ADDRESS="no-reply@example.com"
 APP_LOCALE=en
 
@@ -18,7 +18,7 @@ APP_SECRET="GUNDEALS DEV! THIS MUST NOT BE USED IN PROD OR LIZURDS!"
 # Change the username, password, host, database name and server version
 # according to your setup. Don't even think about trying another kind of
 # database, it won't work
-DATABASE_URL=pgsql://gundealsdev:sendit@localhost:5432/gundeals?serverVersion=9.6
+DATABASE_URL=pgsql://dev:dev@postgres:5432/gundeals?serverVersion=9.6
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Notice**: New Fork of Postmill for gundeals.io project. 
+**Notice**: New Fork of Postmill for gundeals.io project.
 Lets see what we can do ladies an gents!
 Message @TKsM151 in OUR discord to become a collaborator/dev team member.
 
@@ -6,7 +6,7 @@ Message @TKsM151 in OUR discord to become a collaborator/dev team member.
 
 # ![](docs/assets/postmill-128.png) Postmill
 
-**Postmill** is a free, web-based, social link aggregator with voting and threaded comments. 
+**Postmill** is a free, web-based, social link aggregator with voting and threaded comments.
 It is built on the [Symfony](https://symfony.com/) framework.
 
 ## Requirements
@@ -19,14 +19,29 @@ It is built on the [Symfony](https://symfony.com/) framework.
 
 Before you start hacking - run `git config --global --edit` and set up your name correctly, please.
 We also recommend you forward your SSH client to your github from you computer instead of storing any keys on devbox directly.
-(You will need to setup .ssh forwarding in .ssh/config on your local machine). 
+(You will need to setup .ssh forwarding in .ssh/config on your local machine).
 
 * Image linked in Discord should provide everything you need, make sure to pull latest master branch.
 * Then simply Run `cp .env.dev .env; sudo bin/console server:run *:80` to start the application.
-* Navigate to <http://YOURBOXIP:80/>. Log in with: 
-  * gundealsdev 
+* Navigate to <http://YOURBOXIP:80/>. Log in with:
+  * gundealsdev
   * senditree
 9. dbname and pass is in .env file
+
+## Development in docker-compose
+
+There is a docker-compose file in the main directory that will let you run everything locally from the repo.
+
+To get started:
+
+1. install Docker
+2. run `docker-compose up` from the main directory
+
+If you don't have php or node handy:
+* run `scripts/assets.sh && scripts/vendor.sh`
+* `docker-compose run php bash -c './bin/console assets:install'`
+* `docker-compose run php bash -c './bin/console assets:install'`
+* `docker-compose run php bash -c './bin/console doctrine:migrations:migrate'`
 
 ## License
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3.3"
+services:
+  nginx:
+    build: docker/nginx
+    image: gundeals-nginx:latest
+    networks:
+      - gundealsnet
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/var/www/html
+  php:
+    build: docker/php
+    image: gundeals-php:latest
+    ports:
+      - 9000:9000
+    networks:
+      - gundealsnet
+    volumes:
+      - ./:/var/www/html:cached
+      - ./docker/php/php-overrides.ini:/etc/php/7.2/fpm/conf.d/99-overrides.ini
+      - ./.env.dev:/var/www/html/.env
+    working_dir: /var/www/html
+  postgres:
+    image: postgres:9.6.8
+    networks:
+      - gundealsnet
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+networks:
+  gundealsnet:

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx
+
+RUN rm -f /etc/nginx/conf.d/default.conf
+ADD nginx.conf /etc/nginx/
+ADD gundeals.local /etc/nginx/sites-available/gundeals.conf
+RUN ln -s /etc/nginx/sites-available/gundeals.conf /etc/nginx/conf.d/default.conf
+RUN usermod -u 1000 www-data
+
+CMD ["nginx"]

--- a/docker/nginx/gundeals.local
+++ b/docker/nginx/gundeals.local
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html/public;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+
+    location ~ \.php {
+        fastcgi_pass php:9000;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param HTTPS off;
+    }
+
+    error_log /var/log/nginx/gundeals_error.log;
+    access_log /var/log/nginx/gundeals_error.log;
+}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,29 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+  worker_connections  2048;
+  multi_accept on;
+  use epoll;
+}
+
+http {
+  server_tokens off;
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 15;
+  types_hash_max_size 2048;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  access_log off;
+  error_log off;
+  gzip on;
+  gzip_disable "msie6";
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
+  open_file_cache max=100;
+}
+
+daemon off;

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.2-fpm-stretch
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  libpq-dev libcurl4-openssl-dev libpng-dev zlib1g-dev && \
+  pecl install apcu_bc-1.0.4 && \
+  docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql && \
+  docker-php-ext-install pdo pdo_pgsql pgsql && \
+  docker-php-ext-enable apcu && \
+  docker-php-ext-install curl iconv gd opcache && \
+  rm -r /var/lib/apt/lists/* /tmp/*

--- a/docker/php/php-overrides.ini
+++ b/docker/php/php-overrides.ini
@@ -1,0 +1,5 @@
+opcache.max_accelerated_files = 20000
+realpath_cache_size=4096K
+realpath_cache_ttl=600
+php_admin_flag[log_errors] = on
+php_flag[display_errors] = on

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker run --rm -it \
+  -v $PWD:/home/node/app -w /home/node/app \
+  node:8 bash -c 'npm install && npm run build-dev'

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+add-apt-repository -y ppa:ondrej/php
+add-apt-repository -y "deb https://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main"
+curl -L https://www.postgresql.org/media/keys/ACCC4CF8.asc 2>/dev/null | apt-key add -
+
+apt-get update && apt-get install -y \
+  php7.2-cli \
+  php7.2-curl \
+  php7.2-fpm \
+  php7.2-intl \
+  php7.2-pgsql \
+  composer \
+  nginx \
+  nodejs \
+  postgresql-client-9.6 \
+  postgresql-contrib-9.6 \
+  postgresql-common \
+  libpq-dev # TODO I don't think this is the right version

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker run --rm -it \
+   -v $PWD:/app \
+   composer install --ignore-platform-reqs --no-scripts


### PR DESCRIPTION
Also add a simple script for bootstrapping a new server with the
necessary apt packages for running the site

The README should tell you how to use docker-compose to do local
development. Next steps are to dockerize the site and all of the other
components we want running on a server.

Closes #64, I need to add followup tasks for SSM since this PR doesn't
cover that.