### PR TITLE
Issue 84 - Change site-wide announcement into announcement with threa…

### DIFF
--- a/assets/less/components/alert.less
+++ b/assets/less/components/alert.less
@@ -43,4 +43,10 @@
     border: 1px solid @alert-success-border-color;
     background: @alert-success-color;
   }
+
+  &--error {
+    color: @alert-error-text-color;
+    border: 1px solid @alert-error-border-color;
+    background: @alert-error-color;
+  }
 }

--- a/assets/less/settings.less
+++ b/assets/less/settings.less
@@ -59,6 +59,10 @@
 @alert-primary-border-color: #b5cce3;
 @alert-primary-text-color: #172a3e;
 
+@alert-error-color: #f6d0d0;
+@alert-error-border-color: #d99797;
+@alert-error-text-color: #3a1d1d;
+
 // Forms
 @form-error-color: red;
 @form-text-input-background-color: #fff;

--- a/config/app_routes/frontpageconfig.yaml
+++ b/config/app_routes/frontpageconfig.yaml
@@ -2,3 +2,8 @@ frontpageconfig:
     controller: App\Controller\FrontPageConfigurationController::frontPageConfig
     path: /frontpageconfig
     methods: [GET, POST]
+
+frontpageconfig_removeannouncement:
+    controller: App\Controller\FrontPageConfigurationController::removeAnnouncement
+    path: /frontpageconfig/remove_announcement
+    methods: [POST]

--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -4,14 +4,16 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Entity\ForumConfiguration;
+use App\Entity\Submission;
 use App\Repository\ForumRepository;
 use App\Repository\ForumConfigurationRepository;
 use App\Repository\SubmissionRepository;
+use App\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
-use App\Form\ForumConfigurationType;
-use App\Form\Model\ForumConfigurationData;
+use App\Form\NewForumAnnouncementType;
+use App\Form\Model\NewForumAnnouncementData;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -20,37 +22,92 @@ use Symfony\Component\HttpFoundation\Request;
   * @IsGranted("ROLE_ADMIN")
   */
 final class FrontPageConfigurationController extends AbstractController {
-    public function frontPageConfig(ForumRepository $fr, SubmissionRepository $sr, ForumConfigurationRepository $fcr, EntityManager $em, Request $request) {
-        $data = new ForumConfigurationData($fcr->findSitewide());
 
-        $form = $this->createForm(ForumConfigurationType::class, $data);
+    public function frontPageConfig(
+        ForumRepository $fr,
+        SubmissionRepository $sr,
+        ForumConfigurationRepository $fcr,
+        UserRepository $ur,
+        EntityManager $em,
+        Request $request
+    ) {
+        $announcementForumName = "announcements";
+        $data = new NewForumAnnouncementData();
+
+        $form = $this->createForm(NewForumAnnouncementType::class, $data);
         $form->handleRequest($request);
 
         $message = "";
+        $messageClass = "";
 
         if ($form->isSubmitted() && $form->isValid()) {
             $fc = $data->toForumConfiguration();
 
-            // For sitewide settings, we need to force this to null.
-            $fc->setForumId(null);
+            // Find the user and forum for submission.
+            $user = $ur->loadUserByUsername($this->get('security.token_storage')->getToken()->getUser()->getUsername());
+            $forum = $fr->findOneByCaseInsensitiveName($announcementForumName);
 
-            if($fc->getId() == null || trim($fc->getId()) == "")
-                $em->persist($fc);
-            else
-                $em->merge($fc);
+            if($forum != null) {
+                // Create the submission.
+                $submission = new Submission(
+                    $data->threadTitle,
+                    null,
+                    $data->threadContent,
+                    $forum,
+                    $user,
+                    null
+                );
+                $em->persist($submission);
+                $em->flush();
 
-            $em->flush();
+                // Load the current announcement's row id. Sitewide announcemnts have null forum id.
+                $fc->setId($fcr->findSitewide()->getId());
+                $fc->setAnnouncementSubmissionId($submission->getId());
+                $fc->setForumId(null);
 
-            // After saving, pull the data back down again.
-            $data = new ForumConfigurationData($fcr->findSitewide());
-            $form = $this->createForm(ForumConfigurationType::class, $data);
+                if($fc->getId() == null || trim($fc->getId()) == "")
+                    $em->persist($fc);
+                else
+                    $em->merge($fc);
 
-            $message = "front_page_configuration_form.message_saved";
+                $em->flush();
+
+                // After saving, pull the data back down again.
+                $data = new NewForumAnnouncementData();
+                $form = $this->createForm(NewForumAnnouncementType::class, $data);
+
+                $message = "front_page_configuration_form.announcement_saved";
+                $messageClass = "success";
+            } else {
+                $message = "front_page_configuration_form.announcement_forum_error";
+                $messageClass = "error";
+            }
+        }
+
+        // Load the current sitewide so we can show the announcement.
+        $frontpageconfig = $fcr->findSitewide();
+        $announcementSubmission = null;
+        if($frontpageconfig->getAnnouncementSubmissionId() != null) {
+            $announcementSubmission = $em->find("App\\Entity\\Submission", $frontpageconfig->getAnnouncementSubmissionId());
         }
 
         return $this->render('frontpageconfig/frontpageconfig.html.twig', [
             'form' => $form->createView(),
             'message' => $message,
+            'messageClass' => $messageClass,
+            'current_announcement' => $frontpageconfig->getAnnouncement(),
+            'announcementSubmission' => $announcementSubmission,
         ]);
+    }
+
+    public function removeAnnouncement(ForumRepository $fr, SubmissionRepository $sr, ForumConfigurationRepository $fcr, EntityManager $em, Request $request) {
+        $fc = $fcr->findSitewide();
+
+        $fc->setAnnouncement(null);
+        $fc->setAnnouncementSubmissionId(null);
+        $em->merge($fc);
+        $em->flush();
+
+        return $this->redirectToRoute('frontpageconfig');
     }
 }

--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -42,7 +42,7 @@ final class FrontPageConfigurationController extends AbstractController {
 
         if ($form->isSubmitted() && $form->isValid()) {
             // Find the user and forum for submission.
-            $user = $ur->loadUserByUsername($this->get('security.token_storage')->getToken()->getUser()->getUsername());
+            $user = $ur->loadUserByUsername($this->getUser()->getUsername());
             $forum = $fr->findOneByCaseInsensitiveName($announcementForumName);
 
             if($forum != null) {

--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -41,8 +41,6 @@ final class FrontPageConfigurationController extends AbstractController {
         $messageClass = "";
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $fc = $data->toForumConfiguration();
-
             // Find the user and forum for submission.
             $user = $ur->loadUserByUsername($this->get('security.token_storage')->getToken()->getUser()->getUsername());
             $forum = $fr->findOneByCaseInsensitiveName($announcementForumName);
@@ -61,15 +59,12 @@ final class FrontPageConfigurationController extends AbstractController {
                 $em->flush();
 
                 // Load the current announcement's row id. Sitewide announcemnts have null forum id.
-                $fc->setId($fcr->findSitewide()->getId());
+                $fc = $fcr->findSitewide();
                 $fc->setAnnouncementSubmissionId($submission->getId());
+                $fc->setAnnouncement($data->announcement);
                 $fc->setForumId(null);
 
-                if($fc->getId() == null || trim($fc->getId()) == "")
-                    $em->persist($fc);
-                else
-                    $em->merge($fc);
-
+                $em->persist($fc);
                 $em->flush();
 
                 // After saving, pull the data back down again.

--- a/src/Entity/ForumConfiguration.php
+++ b/src/Entity/ForumConfiguration.php
@@ -39,6 +39,13 @@ class ForumConfiguration {
      */
     private $announcement;
 
+    /**
+     * @ORM\Column(type="bigint", nullable=true)
+     *
+     * @var int|null
+     */
+    private $announcementSubmissionId;
+
     public function __construct($forumId) {
         $this->forumId = $forumId;
     }
@@ -65,5 +72,13 @@ class ForumConfiguration {
 
     public function setAnnouncement($announcement) {
         $this->announcement = $announcement;
+    }
+
+    public function getAnnouncementSubmissionId() {
+        return $this->announcementSubmissionId;
+    }
+
+    public function setAnnouncementSubmissionId($id) {
+        $this->announcementSubmissionId = $id;
     }
 }

--- a/src/Form/Model/NewForumAnnouncementData.php
+++ b/src/Form/Model/NewForumAnnouncementData.php
@@ -5,7 +5,7 @@ namespace App\Form\Model;
 use App\Entity\ForumConfiguration;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class ForumConfigurationData {
+class NewForumAnnouncementData {
     /**
      * @var int
      */
@@ -21,10 +21,22 @@ class ForumConfigurationData {
      */
     public $announcement;
 
-    public function __construct(ForumConfiguration $fc) {
-        $this->id = $fc->getId();
-        $this->forumId = $fc->getForumId();
-        $this->announcement = $fc->getAnnouncement();
+    /**
+     * @var string
+     */
+    public $threadTitle;
+
+     /**
+      * @var string
+      */
+    public $threadContent;
+
+    public function __construct(ForumConfiguration $fc = null) {
+        if($fc != null) {
+            $this->id = $fc->getId();
+            $this->forumId = $fc->getForumId();
+            $this->announcement = $fc->getAnnouncement();
+        }
     }
 
     public function toForumConfiguration(): ForumConfiguration {

--- a/src/Form/NewForumAnnouncementType.php
+++ b/src/Form/NewForumAnnouncementType.php
@@ -2,7 +2,7 @@
 
 namespace App\Form;
 
-use App\Form\Model\ForumConfigurationData;
+use App\Form\Model\NewForumAnnouncementData;
 use Symfony\Component\Form\AbstractType;
 use App\Form\Type\MarkdownType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -12,12 +12,20 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ForumConfigurationType extends AbstractType {
+class NewForumAnnouncementType extends AbstractType {
     public function buildForm(FormBuilderInterface $builder, array $options) {
         $builder
-            ->add('announcement', MarkdownType::class, [
+            ->add('announcement', TextType::class, [
                 'label' => 'front_page_configuration_form.announcement',
-                'required' => false
+                'required' => true
+            ])
+            ->add('threadTitle', TextType::class, [
+                'label' => 'front_page_configuration_form.thread_title',
+                'required' => true
+            ])
+            ->add('threadContent', MarkdownType::class, [
+                'label' => 'front_page_configuration_form.thread_content',
+                'required' => true
             ])
             ->add('id', HiddenType::class, [])
             ->add('forumId', HiddenType::class, [])
@@ -28,7 +36,7 @@ class ForumConfigurationType extends AbstractType {
 
     public function configureOptions(OptionsResolver $resolver) {
         $resolver->setDefaults([
-            'data_class' => ForumConfigurationData::class,
+            'data_class' => NewForumAnnouncementData::class,
         ]);
     }
 }

--- a/src/Migrations/Version20180401054730.php
+++ b/src/Migrations/Version20180401054730.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180401054730 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE forum_configuration ADD announcement_submission_id BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id DROP DEFAULT');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE forum_configuration DROP announcement_submission_id');
+        $this->addSql('ALTER TABLE moderators ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE moderators ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE forum_subscriptions ALTER id DROP DEFAULT');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id TYPE UUID');
+        $this->addSql('ALTER TABLE wiki_revisions ALTER id DROP DEFAULT');
+    }
+}

--- a/templates/front/base.html.twig
+++ b/templates/front/base.html.twig
@@ -18,7 +18,11 @@
 {% endblock %}
 
 {% block body %}
-  {% if announcement != null %}<div class="form-message form-message--primary text-center">{{ announcement|cached_markdown(markdown_context())|raw }}</div>{% endif %}
+  {% if announcement != null %}
+      <div class="form-message form-message--primary text-center">
+          <a href="{{ path('submission', {forum_name: announcementSubmission.forum.name, submission_id: announcementSubmission.id, slug: announcementSubmission.title|slugify}) }}">{{ announcement|cached_markdown(markdown_context())|raw }}</a>
+      </div>
+  {% endif %}
 
   <nav class="tabs submission-sort">
     <ul class="tabs__bar">{{ submission_sort(sort_by) }}</ul>

--- a/templates/frontpageconfig/frontpageconfig.html.twig
+++ b/templates/frontpageconfig/frontpageconfig.html.twig
@@ -6,7 +6,24 @@
 
 {% block body %}
   <h1 class="page-heading">{{ block('title') }}</h1>
+  {% if message != "" %}<div class='form-message form-message--{{messageClass}}'>
+    <p>{{ message|trans }}</p></div>
+  {% endif %}
 
-  {% if message != "" %}<div class='form-message form-message--success'><p>{{ message|trans }}</p></div>{% endif %}
-  {{ form(form) }}
+  {% if current_announcement != "" %}
+    <p>
+      <h2>Current announcement</h2>
+      <form action="/frontpageconfig/remove_announcement" method="POST">        
+        <div class="form-message form-message--primary text-center">
+          <p><a href="{{ path('submission', {forum_name: announcementSubmission.forum.name, submission_id: announcementSubmission.id, slug: announcementSubmission.title|slugify}) }}" target="_blank">{{current_announcement}}</a></p>
+        </div>
+        <button class="button">{{ "front_page_configuration_form.remove_announcement"|trans }}</button>
+      </form>
+    </p>
+  {% endif %}
+
+  <p>
+    <h2>Post new announcement</h2>
+    {{ form(form) }}
+  </p>
 {% endblock %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -547,6 +547,10 @@ wiki_form:
     submit: Submit
 
 front_page_configuration_form:
-    announcement: Announcement
-    save: Save Changes
-    message_saved: The changes have been saved.
+    announcement: Global Header
+    save: Add new announcement
+    announcement_saved: Your announcement has been posted.
+    announcement_forum_error: Could not find the announcements forum.
+    remove_announcement: Remove current announcement
+    thread_title: Announcement Title
+    thread_content: Global Announcement


### PR DESCRIPTION
Issue #84 

The sitewide announcement page has been made to act as a post submission page

Note: a forum with the name of "announcements" is required.

To test this issue:
- Log in as an admin
- Click "Front Page Configuration" under the "Admin" menu in the navigation bar.
- Enter the global header, announcement title and and announcement content.
- Click "Add new announcement".

To remove the global announcement header
- Click "Front Page Configuration" under the "Admin" menu in the navigation bar.
- Click "Remove current announcement".