### PR TITLE
Issue 84 - Fix featured/all front pages.

### DIFF
--- a/src/Controller/FrontController.php
+++ b/src/Controller/FrontController.php
@@ -51,14 +51,14 @@ final class FrontController extends AbstractController {
 
         switch ($listing) {
           case User::FRONT_SUBSCRIBED:
-              return $this->subscribed($fr, $sr, $fcr, $sortBy, $page);
+              return $this->subscribed($fr, $sr, $fcr, $em, $sortBy, $page);
           case User::FRONT_FEATURED:
-              return $this->featured($fr, $sr, $fcr, $sortBy, $page);
+              return $this->featured($fr, $sr, $fcr, $em, $sortBy, $page);
           case User::FRONT_ALL:
               //return $this->all($sr, $sortBy, $page, $siteConfig);
-              return $this->all($fr, $sr, $fcr, $sortBy, $page);
+              return $this->all($fr, $sr, $fcr, $em, $sortBy, $page);
           case User::FRONT_MODERATED:
-              return $this->moderated($fr, $sr, $fcr, $sortBy, $page);
+              return $this->moderated($fr, $sr, $fcr, $em, $sortBy, $page);
           default:
               throw new \InvalidArgumentException('bad front page selection');
         }


### PR DESCRIPTION
I didn't foresee that these methods would get hit by a route directly, so these were all busted. I stripped out the announcement retrieval from the `front` method and put it into each individual method.

Test steps:
- Navigate to each of the front page types (featured, subscribed, hot, new, etc)
- Make sure it isn't erroring
- Add an announcement via the Front Page Configuration page
- Re-try all of the front pages.