### PR TITLE
Issue 84 - Fix issue with null announcement submission on front page …

### DIFF
--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -86,10 +86,13 @@ final class FrontPageConfigurationController extends AbstractController {
             $announcementSubmission = $em->find("App\\Entity\\Submission", $frontpageconfig->getAnnouncementSubmissionId());
         }
 
+        $hasAnnouncement = !($announcementSubmission == null || empty($frontpageconfig->getAnnouncement()));
+
         return $this->render('frontpageconfig/frontpageconfig.html.twig', [
             'form' => $form->createView(),
             'message' => $message,
             'messageClass' => $messageClass,
+            'has_announcement' => $hasAnnouncement,
             'current_announcement' => $frontpageconfig->getAnnouncement(),
             'announcementSubmission' => $announcementSubmission,
         ]);

--- a/templates/frontpageconfig/frontpageconfig.html.twig
+++ b/templates/frontpageconfig/frontpageconfig.html.twig
@@ -10,10 +10,10 @@
     <p>{{ message|trans }}</p></div>
   {% endif %}
 
-  {% if current_announcement != "" %}
+  {% if has_announcement %}
     <p>
       <h2>Current announcement</h2>
-      <form action="/frontpageconfig/remove_announcement" method="POST">        
+      <form action="/frontpageconfig/remove_announcement" method="POST">
         <div class="form-message form-message--primary text-center">
           <p><a href="{{ path('submission', {forum_name: announcementSubmission.forum.name, submission_id: announcementSubmission.id, slug: announcementSubmission.title|slugify}) }}" target="_blank">{{current_announcement}}</a></p>
         </div>


### PR DESCRIPTION
This fixes an issue where there is no announcement but the twig is not preventing the "current announcement" block from showing.

To test this issue:
- Navigate to the front page config page
- Set an announcement
- Clear the announcement
- If the front page config page loads correctly, the issue is fixed.