### PR TITLE
Enable logger for Controllers to Console/Docker log

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -13,7 +13,12 @@ monolog:
         #chromephp:
         #    type: chromephp
         #    level: info
-        console:
-            type:   console
-            process_psr_3_messages: false
-            channels: ["!event", "!doctrine", "!console"]
+        #console:
+        #    type:   console
+        #    process_psr_3_messages: false
+        #    channels: ["!event", "!doctrine", "!console", "!app"]
+        nested:
+            channels: ["app"]
+            type:  stream
+            path:  "php://stderr"
+            level: debug

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,7 +31,9 @@ services:
     App\Controller\:
         resource: '../src/Controller'
         public: true
-        tags: ['controller.service_arguments']
+        tags:
+          - 'controller.service_arguments'
+          - { name: monolog.logger, channel: app }
 
     App\Command\ActivateMaintenanceMode:
         arguments:

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -4,8 +4,15 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as BaseAbstractController;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 abstract class AbstractController extends BaseAbstractController {
+    protected $logger = null;
+    public function __construct(LoggerInterface $logger = null) {
+        $this->logger = $logger ?: new NullLoger();
+    }
+
     protected function validateCsrf(string $id, string $token) {
         if (!$this->isCsrfTokenValid($id, $token)) {
             throw new BadRequestHttpException('Invalid CSRF token');

--- a/src/Controller/FrontController.php
+++ b/src/Controller/FrontController.php
@@ -11,6 +11,7 @@ use App\Repository\SubmissionRepository;
 use App\Utils\PermissionsChecker;
 use Symfony\Component\HttpFoundation\Response;
 use Doctrine\ORM\EntityManager;
+use Psr\Log\LoggerInterface;
 
 /**
  * Actions that list submissions across many forums.
@@ -30,7 +31,9 @@ use Doctrine\ORM\EntityManager;
  *   instead.
  */
 final class FrontController extends AbstractController {
-    public function front(ForumRepository $fr, SubmissionRepository $sr, ForumConfigurationRepository $fcr, string $sortBy, int $page, EntityManager $em) {
+
+    public function front(ForumRepository $fr, SubmissionRepository $sr, ForumConfigurationRepository $fcr, string $sortBy, int $page, EntityManager $em, LoggerInterface $logger=null) {
+        #$this->logger->info('Front start');
         $user = $this->getUser();
 
         $siteConfig = $fcr->findSitewide();


### PR DESCRIPTION
monolog.yaml changes output log into docker log / stdout (if you run docker-compose up without -d)
Prev. console (commented out) was outputing anything but event, doctrine, console and app channels.
Mine does app only.

services.yaml is an example how to tag a service with channel and enable monolog, for controllers it's passed in method function, for src/EventListener/SubmissionImageListener.php - it is already passed through constructor - see the differences in services.yaml,

What's funny -both $this->logger & $logger arg can be used. Looks like tag adds it as a last parameter to the method

Test Plan:
1. Run in tmux window with ./dev-aws.sh
2. Uncomment logger->debug from another window
3. go to front - observe app.INFO: Front start [] []
4. Change $this->logger to $logger
5. Repeat 3. - should work the same
6. Change message to make sure changes propagated and it actually works
