### PR TITLE
Fix Thumbnails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,10 +76,14 @@ RUN cd /var/www && npm install
 WORKDIR /var/www/public
 CMD ["sh", "-c", "cd /var/www; \
                  cp /tmp/.env /var/www/.env; \
-                 chown 1000:1000 /var/www/.env; \
+                 chown www-data:www-data /var/www/.env; \
                  composer install; npm run build-dev; \
                  cp /tmp/.env /var/www/.env && rm /tmp/.env && rm /tmp/env.erb;\
-                 chown 1000:1000 /var/www/.env; \
+                 chown www-data:www-data /var/www/.env; \
+                 mkdir -p ./public/media/; chown www-data:www-data public/media -R; \
+                 mkdir -p ./public/submission_images/; chown www-data:www-data public/submission_images -R; \
+                 mkdir -p ./var/cache/; chown www-data:www-data ./var/cache/ -R; \
                  bin/console doctrine:migrations:migrate --no-interaction; \
                  bin/console app:user:add -a -p devdevdev dev; \
                  cd /var/www/public; php-fpm"]
+

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -81,8 +81,9 @@ RUN npm install
 
 WORKDIR /var/www/public
 CMD ["sh", "-c", "cd /var/www; \
-                  mkdir -p ./public/submission_images/; chown www-data:www-data public/submission_images -R \
-                  mkdir -p ./var/cache/; chown www-data:www-data ./var/cache/ -R \
+                  mkdir -p ./public/submission_images/; chown www-data:www-data public/submission_images -R; \
+                  mkdir -p ./var/cache/; chown www-data:www-data ./var/cache/ -R; \
+                  mkdir -p ./public/media/; chown www-data:www-data public/media -R; \
                   composer install; npm run build-prod; npm run build-dev; cd /var/www/public; cp /tmp/.env /var/www/.env; rm /tmp/.env*; php-fpm"]
 
 # uncomment for lighter container and slower incremental build

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -80,7 +80,10 @@ WORKDIR /var/www
 RUN npm install
 
 WORKDIR /var/www/public
-CMD ["sh", "-c", "cd /var/www; composer install; npm run build-prod; npm run build-dev; cd /var/www/public; cp /tmp/.env /var/www/.env; rm /tmp/.env*; php-fpm"]
+CMD ["sh", "-c", "cd /var/www; \
+                  mkdir -p ./public/submission_images/; chown www-data:www-data public/submission_images -R \
+                  mkdir -p ./var/cache/; chown www-data:www-data ./var/cache/ -R \
+                  composer install; npm run build-prod; npm run build-dev; cd /var/www/public; cp /tmp/.env /var/www/.env; rm /tmp/.env*; php-fpm"]
 
 # uncomment for lighter container and slower incremental build
 # RUN apt-get purge   -y nodejs

--- a/assets/js/fetch_titles.js
+++ b/assets/js/fetch_titles.js
@@ -18,6 +18,9 @@ $(function () {
                 if ($receiver.val().trim() === '') {
                     $('.receive-title').val(data.title);
                 }
+                if (data.image) {
+                  $('#submission_originalImage').val(data.image);
+                }
             }).fail(err => {
                 console && console.log(err);
             });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,9 @@ services:
     volumes:
       - "./docker/nginx/letsencrypt:/etc/letsencrypt/:rw"
       - "./docker/nginx/nginxlogs/:/var/log/nginx/:rw"
-      - "wwwdir:/var/www/:ro"
+      - "./public:/var/www/public:ro"
+      - "./vendor:/var/www/vendor:ro"
+
   php-dev-local:
     build:
       context: .
@@ -42,8 +44,16 @@ services:
     links:
       - db-dev-local
     volumes:
-      - "wwwdir:/var/www:rw"
+      - "./public:/var/www/public:rw"
+      - "./lib:/var/www/lib:rw"
+      - "./var:/var/www/var:rw"
+      - "./vendor:/var/www/vendor:rw"
+      - "./assets:/var/www/assets:ro"
       - "./bin:/var/www/bin:ro"
+      - "./config:/var/www/config:rw"
+      - "./src:/var/www/src:ro"
+      - "./templates:/var/www/templates:ro"
+      - "./translations:/var/www/translations:ro"
     working_dir: /var/www/public
 
   db-dev-local:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,7 +64,3 @@ services:
       POSTGRES_USER: developer
       POSTGRES_PASSWORD: devdevdev
       POSTGRES_DB: devdb
-
-volumes:
-  wwwdir:
-

--- a/docker-compose.yaml.aws.erb
+++ b/docker-compose.yaml.aws.erb
@@ -52,7 +52,7 @@ services:
     volumes:
       - ./src:/var/www/src
       - ./templates:/var/www/templates
-      - ./config:/var/www/config
+      - "./config:/var/www/config:rw"
       - "./public:/var/www/public:rw"
       - "./assets:/var/www/assets:ro"
       - "./bin:/var/www/bin:ro"

--- a/docker-compose.yaml.aws.erb
+++ b/docker-compose.yaml.aws.erb
@@ -32,7 +32,8 @@ services:
     volumes:
       - "./docker/nginx/letsencrypt:/etc/letsencrypt/:rw"
       - "./docker/nginx/nginxlogs/:/var/log/nginx/:rw"
-      - "wwwdir:/var/www/:ro"
+      - "./public:/var/www/public:ro"
+      - "./vendor:/var/www/vendor:ro"
 
   php:
     build:
@@ -49,13 +50,15 @@ services:
         - mailer_url="<%=mailer_url.strip%>"
     working_dir: /var/www/public
     volumes:
-      - "wwwdir:/var/www:rw"
       - ./src:/var/www/src
       - ./templates:/var/www/templates
+      - ./config:/var/www/config
+      - "./public:/var/www/public:rw"
+      - "./assets:/var/www/assets:ro"
+      - "./bin:/var/www/bin:ro"
+      - "./lib:/var/www/lib:rw"
+      - "./translations:/var/www/translations:rw"
+      - "./var:/var/www/var:rw"
+      - "./vendor:/var/www/vendor:rw"
     expose:
       - '9000'
-
-volumes:
-  wwwdir:
-  publicdir:
-  libdir:

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -31,13 +31,15 @@ class AjaxController {
     public function fetchTitle(Request $request) {
         $url = $request->request->get('url');
         try {
-            $title = Embed::create($url)->getTitle();
+            $info = Embed::create($url);
+            $title = $info->getTitle();
+            $image = $info->getImage();
 
             if (!strlen($title)) {
                 return new JsonResponse(null, 404);
             }
 
-            return new JsonResponse(['title' => $title]);
+            return new JsonResponse(['title' => $title, 'image' => $image]);
         } catch (InvalidUrlException $e) {
             return new JsonResponse(['error' => $e->getMessage()], 400);
         }

--- a/src/Entity/Submission.php
+++ b/src/Entity/Submission.php
@@ -99,6 +99,14 @@ class Submission extends Votable {
     private $image;
 
     /**
+     * URL to remote website's image
+     * @ORM\Column(type="text", nullable=true)
+     *
+     * @var string
+     */
+    private $originalImage;
+
+    /**
      * @ORM\Column(type="inet", nullable=true)
      *
      * @var string|null
@@ -171,7 +179,8 @@ class Submission extends Votable {
         bool $sticky = false,
         bool $modThread = false,
         int $userFlag = UserFlags::FLAG_NONE,
-        \DateTime $timestamp = null
+        \DateTime $timestamp = null,
+        ?string $originalImage = null
     ) {
         if ($ip !== null && !filter_var($ip, FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException('Invalid IP address');
@@ -194,6 +203,7 @@ class Submission extends Votable {
         $this->comments = new ArrayCollection();
         $this->votes = new ArrayCollection();
         $this->vote($user, $ip, Votable::VOTE_UP);
+        $this->originalImage = $originalImage;
     }
 
     public function getId(): ?int {
@@ -318,6 +328,14 @@ class Submission extends Votable {
 
     public function setImage(?string $image) {
         $this->image = $image;
+    }
+
+    public function getOriginalImage(): ?string {
+        return $this->originalImage;
+    }
+
+    public function setOriginalImage(?string $image) {
+        $this->originalImage = $image;
     }
 
     public function getIp(): ?string {

--- a/src/Form/Model/SubmissionData.php
+++ b/src/Form/Model/SubmissionData.php
@@ -35,6 +35,14 @@ class SubmissionData {
     private $url;
 
     /**
+     * @Assert\Length(max=2000, charset="8bit", groups={"create", "edit"})
+     * @Assert\Url(protocols={"http", "https"}, groups={"create", "edit"})
+     *
+     * @var string|null
+     */
+    private $originalImage;
+
+    /**
      * @Assert\Length(max=25000, groups={"create", "edit"})
      *
      * @var string|null
@@ -63,6 +71,7 @@ class SubmissionData {
         $self->entityId = $submission->getId();
         $self->title = $submission->getTitle();
         $self->url = $submission->getUrl();
+        $self->originalImage= $submission->getOriginalImage();
         $self->body = $submission->getBody();
         $self->userFlag = $submission->getUserFlag();
         $self->forum = $submission->getForum();
@@ -82,7 +91,9 @@ class SubmissionData {
             $ip,
             $this->sticky,
             $modThread,
-            $this->userFlag
+            $this->userFlag,
+            null,
+            $this->originalImage
         );
     }
 
@@ -92,6 +103,7 @@ class SubmissionData {
         $submission->setBody($this->body);
         $submission->setUserFlag($this->userFlag);
         $submission->setSticky($this->sticky);
+        $submission->setOriginalImage($this->originalImage);
     }
 
     public function getEntityId() {
@@ -112,6 +124,14 @@ class SubmissionData {
 
     public function setUrl($url) {
         $this->url = $url;
+    }
+
+    public function getOriginalImage() {
+        return $this->originalImage;
+    }
+
+    public function setOriginalImage($url) {
+        $this->originalImage = $url;
     }
 
     public function getBody() {

--- a/src/Form/SubmissionType.php
+++ b/src/Form/SubmissionType.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -58,6 +59,7 @@ final class SubmissionType extends AbstractType {
         $builder
             ->add('title', TextareaType::class)
             ->add('url', UrlType::class, ['required' => false])
+            ->add('originalImage', HiddenType::class, ['required' => false])
             ->add('body', MarkdownType::class, [
                 'required' => false,
             ]);

--- a/src/Migrations/Version20180407235238.php
+++ b/src/Migrations/Version20180407235238.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20180407235238 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->addSql('ALTER TABLE submissions ADD original_image TEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->addSql('ALTER TABLE submissions DROP original_image');
+    }
+}


### PR DESCRIPTION
### Main Fix - Permissions 
./public/submission_images is where full thumbnail image is stored when uploaded 
(it first goes to /tmp/ then gets verified and copied into public/submission_images)

./var/cache is a place where imagine plugin/lib( no idea wtf that thing is, except twig uses i) stores scaled? or somehow changed version of it?

Due to change to docker - we had bad permissions/ownership for these folders, so I had to manually chown them on start. TODO: update Dockerfile as well

### Original Image
Embed library sometimes gets image from url, but then from same url - it returns null.
I had a suspicion that requesting it twice in short period of time (fetch title uses that) can cause this issue. So just in case I decided to store originalImage in DB, coming from fetchTitle.js (hidden form input) and use it in conversion/saving of image on disk, when Embed doesn't have one right now.

### docker-compose
Our setup kinda sucks for docker - we have to share disk between nginx & php, I tried with named volumes, but it got cached. So I have to manually give access to folders that are used. TODO: modify docker-compose.yaml to do the same.

While playing with src/EventListener/SubmissionImageListener.php step by step I improved some exception catches and logs just to make it easier to debug same issue in the future. I would like to keep it with this commit, to maintain history and issue/tracking. 

### PR Progress
 - [x] Make ./dev-aws.sh thumbnails work
 - [x] Make ./dev-local.sh thumbnails work
   - [x] Dockerfile
   - [x] Compose file
   - [x] Test uploading links from devbox with thumbnails