### PR TITLE
Fix ORM issues with Reports & RateLimits - Fixes #182

### DIFF
--- a/src/Entity/Forum.php
+++ b/src/Entity/Forum.php
@@ -131,7 +131,7 @@ class Forum {
     private $logEntries;
 
     /**
-     * @ORM\OneToOne(targetEntity="RateLimit", mappedBy="forum")
+     * @ORM\OneToMany(targetEntity="RateLimit", mappedBy="forum")
      * @ORM\OrderBy({"group": "ASC"})
      *
      * @var RateLimit[]|Collection|Selectable

--- a/src/Entity/Forum.php
+++ b/src/Entity/Forum.php
@@ -131,8 +131,8 @@ class Forum {
     private $logEntries;
 
     /**
-     * @ORM\OneToMany(targetEntity="RateLimit", mappedBy="forum")
-     * @ORM\OrderBy({"group_id": "ASC"})
+     * @ORM\OneToOne(targetEntity="RateLimit", mappedBy="forum")
+     * @ORM\OrderBy({"group": "ASC"})
      *
      * @var RateLimit[]|Collection|Selectable
      */

--- a/src/Entity/RateLimit.php
+++ b/src/Entity/RateLimit.php
@@ -26,7 +26,7 @@ class RateLimit {
     private $group;
 
     /**
-     * @ORM\OneToOne(targetEntity="Forum", inversedBy="rateLimits")
+     * @ORM\ManyToOne(targetEntity="Forum", inversedBy="rateLimits")
      */
     private $forum;
 

--- a/src/Entity/RateLimit.php
+++ b/src/Entity/RateLimit.php
@@ -47,7 +47,7 @@ class RateLimit {
         $this->block = $block;
     }
 
-    public function getId(): int {
+    public function getId(): ?int {
         return $this->id;
     }
 

--- a/src/Entity/RateLimit.php
+++ b/src/Entity/RateLimit.php
@@ -26,7 +26,7 @@ class RateLimit {
     private $group;
 
     /**
-     * @ORM\OneToOne(targetEntity="Forum")
+     * @ORM\OneToOne(targetEntity="Forum", inversedBy="rateLimits")
      */
     private $forum;
 
@@ -47,7 +47,7 @@ class RateLimit {
         $this->block = $block;
     }
 
-    public function getId(): ?int {
+    public function getId(): int {
         return $this->id;
     }
 

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -41,7 +41,7 @@ class Report {
 
     /**
      * One report may have one comment.
-     * @ORM\OneToOne(targetEntity="Comment")
+     * @ORM\OneToOne(targetEntity="Comment", inversedBy="reportEntries")
      * @ORM\JoinColumn(name="comment_id", referencedColumnName="id", nullable=true, onDelete="CASCADE")
      */
     private $comment;

--- a/src/Entity/UserGroup.php
+++ b/src/Entity/UserGroup.php
@@ -73,7 +73,7 @@ class UserGroup {
         $this->users = new ArrayCollection();
     }
 
-    public function getId(): int {
+    public function getId(): ?int {
         // todo: replace with UUID
         return $this->id;
     }

--- a/src/Entity/UserGroup.php
+++ b/src/Entity/UserGroup.php
@@ -59,8 +59,8 @@ class UserGroup {
     private $displayTitle = false;
 
     /**
-     * @ORM\OneToMany(targetEntity="RateLimit", mappedBy="forum_id")
-     * @ORM\OrderBy({"forum_id": "ASC"})
+     * @ORM\OneToMany(targetEntity="RateLimit", mappedBy="forum")
+     * @ORM\OrderBy({"forum": "ASC"})
      *
      * @var RateLimit[]|Collection|Selectable
      */
@@ -73,7 +73,7 @@ class UserGroup {
         $this->users = new ArrayCollection();
     }
 
-    public function getId(): ?int {
+    public function getId(): int {
         // todo: replace with UUID
         return $this->id;
     }


### PR DESCRIPTION
Related Issues: #182

Changes:
1) ORM maps by name of the variable, not column name, so we change group_id to group in ORM annotations
2) add inversedBy
3)Fix Many|One 

Test Plan(required):
- Open front & look at the profiler bar - should be no errors
- Create a forum & open forums list - should be visible in forums list
