### PR TITLE
Fix announcements - Fixes #180

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,13 @@
 - Every PR should have issue in both branch name & PR description
 - If you found a new issue that you want to work on - create an issue first.
 
+### Migrations & DB Schema
+- Any DB work & changes must first be done & thoroughly tested on local (./dev-local.sh) db
+- Use `docker exec -ti DB_CONTAINER_NAME bash` and `cd ..; bin/console doctrine:migrations:diff|migrate` to work with local db
+- Manually edit resulting migrations files to remove any unneccessary statements.
+- Include any DB changes in PR description
+- If you're changing existing entities - make sure your Test Plan includes regression testing for all pages these Entities are used in
+
 ### Where to help
 - Look up issue for current upcoming milestone with 'upforgrabs' or 'helpneeded' tags
 

--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -18,7 +18,7 @@ monolog:
         #    process_psr_3_messages: false
         #    channels: ["!event", "!doctrine", "!console", "!app"]
         nested:
-            channels: ["app"]
+            channels: ["app", "doctrine", "console"]
             type:  stream
             path:  "php://stderr"
             level: debug

--- a/db-local.sh
+++ b/db-local.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export GIT_SHA=`git rev-parse --short HEAD`;
+export GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`;
+docker-compose exec db-dev-local psql -U developer -d devdb;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
       - "./bin:/var/www/bin:ro"
       - "./config:/var/www/config:rw"
       - "./src:/var/www/src:ro"
+      - "./src/Migrations/:/var/www/src/Migrations:rw"
       - "./templates:/var/www/templates:ro"
       - "./translations:/var/www/translations:ro"
     working_dir: /var/www/public

--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -106,6 +106,7 @@ final class FrontPageConfigurationController extends AbstractController {
         $fc->setAnnouncementSubmissionId(null);
         $em->merge($fc);
         $em->flush();
+        $em->getConfiguration()->getResultCacheImpl()->delete('sitewide_forum_config');
 
         return $this->redirectToRoute('frontpageconfig');
     }

--- a/src/Controller/FrontPageConfigurationController.php
+++ b/src/Controller/FrontPageConfigurationController.php
@@ -66,6 +66,7 @@ final class FrontPageConfigurationController extends AbstractController {
 
                 $em->persist($fc);
                 $em->flush();
+                $em->getConfiguration()->getResultCacheImpl()->delete('sitewide_forum_config');
 
                 // After saving, pull the data back down again.
                 $data = new NewForumAnnouncementData();

--- a/src/Migrations/Version20180425200406.php
+++ b/src/Migrations/Version20180425200406.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20180425200406 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+      $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+      $this->addSql("INSERT INTO forums (id, name, title, sidebar, created, normalized_name) SELECT NEXTVAL('forums_id_seq'), 'announcements', 'announcements', '', current_timestamp, 'announcements' WHERE NOT EXISTS (SELECT 1 FROM FORUMS WHERE NAME = 'announcements');");
+    }
+
+    public function down(Schema $schema)
+    {
+      $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+      $this->addSql("DELETE FROM forums WHERE id IN (SELECT id FROM forums WHERE name='announcements' LIMIT 1);");
+    }
+}

--- a/src/Repository/ForumRepository.php
+++ b/src/Repository/ForumRepository.php
@@ -75,7 +75,7 @@ final class ForumRepository extends ServiceEntityRepository {
 
         $qb->addOrderBy('f.normalizedName', 'ASC')->groupBy('f.id');
 
-        $q = $qb->getQuery()->useQueryCache(true)->useResultCache(true);
+        $q = $qb->getQuery()->useQueryCache(true)->useResultCache(true, 30);
         $pager = new Pagerfanta(new DoctrineORMAdapter($q));
         $pager->setMaxPerPage(25);
         $pager->setCurrentPage($page);
@@ -100,7 +100,7 @@ final class ForumRepository extends ServiceEntityRepository {
             ') ORDER BY f.normalizedName ASC';
 
         $names = $this->getEntityManager()->createQuery($dql)
-            ->setParameter(1, $user)->useResultCache(true)
+            ->setParameter(1, $user)->useResultCache(true, 30)
             ->getResult();
 
         return array_column($names, 'name', 'id');
@@ -119,7 +119,7 @@ final class ForumRepository extends ServiceEntityRepository {
             ->andWhere('f.id > 0')
             ->orderBy('f.normalizedName', 'ASC')
             ->getQuery()
-            ->useQueryCache(true)->useResultCache(true)
+            ->useQueryCache(true)->useResultCache(true, 30)
             ->execute();
 
         return array_column($names, 'name', 'id');
@@ -138,7 +138,7 @@ final class ForumRepository extends ServiceEntityRepository {
             ->addSelect('f.name')
             ->orderBy('f.normalizedName', 'ASC')
             ->getQuery()
-            ->useQueryCache(true)->useResultCache(true)
+            ->useQueryCache(true)->useResultCache(true, 30)
             ->execute();
 
         return array_column($names, 'name', 'id');
@@ -157,7 +157,7 @@ final class ForumRepository extends ServiceEntityRepository {
 
         $names = $this->getEntityManager()->createQuery($dql)
             ->setParameter(1, $user)
-            ->useResultCache(true)
+            ->useResultCache(true, 30)
             ->getResult();
 
         return array_column($names, 'name', 'id');
@@ -172,7 +172,7 @@ final class ForumRepository extends ServiceEntityRepository {
 
         $names = $this->_em->createQuery($dql)
             ->setParameter(1, $names)
-            ->useResultCache(true)
+            ->useResultCache(true, 30)
             ->getResult();
 
         return array_column($names, 'name', 'id');
@@ -187,7 +187,7 @@ final class ForumRepository extends ServiceEntityRepository {
         if (!$isAdmin) {
             $qb->andWhere('f.id > 0');
         }
-        $forums = $qb->getQuery()->useQueryCache(true)->useResultCache(true)->execute();
+        $forums = $qb->getQuery()->useQueryCache(true)->useResultCache(true, 30)->execute();
         return $forums;
     }
 
@@ -200,7 +200,7 @@ final class ForumRepository extends ServiceEntityRepository {
 
         $names = $this->_em->createQuery($dql)
             ->setParameter('category', $category)
-            ->useResultCache(true)
+            ->useResultCache(true, 30)
             ->getResult();
 
         return array_column($names, 'name', 'id');
@@ -212,7 +212,7 @@ final class ForumRepository extends ServiceEntityRepository {
             ->setMaxResults(1)
             ->getQuery()
             ->useQueryCache(true)
-            ->useResultCache(true)
+            ->useResultCache(true, 30)
             ->execute();
 
         if (is_null($modForum[0]->getCategory())) {

--- a/src/Repository/SubmissionRepository.php
+++ b/src/Repository/SubmissionRepository.php
@@ -101,7 +101,7 @@ class SubmissionRepository extends ServiceEntityRepository {
         if (!$admin) {
             $qb->andWhere('s.forum > 0');
         }
-        $q = $qb->getQuery()->useQueryCache(true)->useResultCache(true);
+        $q = $qb->getQuery()->useQueryCache(true)->useResultCache(true, 30);
         $submissions = $this->paginate($q, $page);
 
         $this->hydrateAssociations($submissions);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -96,7 +96,7 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
             ->setParameter(1, $email)
             ->setParameter(2, User::normalizeEmail($email))
             ->getQuery()
-            ->useQueryCache(true)->useResultCache(true)
+            ->useQueryCache(true)->useResultCache(true, 30)
             ->execute();
     }
 
@@ -132,7 +132,7 @@ EOSQL;
         $contributions = $this->_em->createNativeQuery($sql, $rsm)
             ->setParameter(':user_id', $user->getId())
             ->setParameter(':limit', $limit, 'integer')
-            ->useResultCache(true)
+            ->useResultCache(true, 30)
             ->execute();
 
         if (!empty($contributions['comment']['ids'])) {
@@ -156,7 +156,7 @@ EOSQL;
                 ->where('s.id IN (?1)')
                 ->getQuery()
                 ->setParameter(1, $contributions['submission']['ids'])
-                ->useQueryCache(true)->useResultCache(true)
+                ->useQueryCache(true)->useResultCache(true, 30)
                 ->execute();
         }
 
@@ -195,7 +195,7 @@ EOSQL;
 
         $sth = $this->_em->getConnection()->prepare($sql);
         $sth->bindValue(':id', $user->getId());
-        $sth->useQueryCache(true)->useResultCache(true);
+        $sth->useQueryCache(true)->useResultCache(true, 30);
         $sth->execute();
 
         while ($ip = $sth->fetchColumn()) {
@@ -207,7 +207,7 @@ EOSQL;
         $qb = $this->createQueryBuilder('u')
             ->where('u.group = :group')
             ->setParameter('group', $userGroup);
-        $q = $qb->getQuery()->useQueryCache(true)->useResultCache(true);
+        $q = $qb->getQuery()->useQueryCache(true)->useResultCache(true, 30);
         $pager = new Pagerfanta(new DoctrineORMAdapter($q, false, false));
         $pager->setMaxPerPage(25);
         $pager->setCurrentPage($page);


### PR DESCRIPTION
Related Issues: #180 

Changes:
- fix cache not invalidated when creating/deleting announcements
- limit cache lifetime to 30 seconds
- enable console output for doctrine in dev
- improve CONTRIBUTING re: DB work
- allow migrations to be changed from php container when running bin/console doctrine:migrations:diff
- add a migration that adds announcement forum

Test Plan(required):
- Create announcement sitewide, go to front - should be immediately visible
- Remove announcement - should be immediately gone
